### PR TITLE
removed colon from path validation

### DIFF
--- a/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
+++ b/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
@@ -186,7 +186,7 @@ const validateInt = (val) => {
 
 const validatePath = (val) => {
   /*eslint-disable */
-  if (val.match(/^.*?(?=[\^#%&$\*:<>\?\{\|\} ]).*$/)) {
+  if (val.match(/^.*?(?=[\^#%&$\*<>\?\{\|\} ]).*$/)) {
   /*eslint-enable */
     return 'Invalid characters';
   }


### PR DESCRIPTION
**ISSUE:**
Colon was erroneously reported as an error in container image name path during network element configuration.

**CHANGES:**
- Removed colon from path error checking

**NOTES:**
Cypress tests pass.
