### PR TITLE
Pod Placement

### DIFF
--- a/charts/meep-virt-engine/virt-templates/values-template.yaml
+++ b/charts/meep-virt-engine/virt-templates/values-template.yaml
@@ -55,9 +55,19 @@ deployment:
 
   nodeSelector: {}
   tolerations: []
-  affinity: {}
-
-
+  affinity: 
+  {{- if .Deployment.PlacementId}}
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: In
+            values:
+            - {{.Deployment.PlacementId}}
+  {{- else}}
+    {}
+  {{- end}}
 
 service:
   enabled: {{.Service.Enabled}}

--- a/examples/demo1/src/demo-server/go/README.md
+++ b/examples/demo1/src/demo-server/go/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 0.0.1
-- Build date: 2019-09-17T14:39:27.445-04:00
+- Build date: 2019-09-27T16:00:45.233-04:00
 
 
 ### Running the server

--- a/examples/demo1/src/iperf-proxy/go/README.md
+++ b/examples/demo1/src/iperf-proxy/go/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 0.0.1
-- Build date: 2019-09-17T14:39:29.528-04:00
+- Build date: 2019-09-27T16:00:46.300-04:00
 
 
 ### Running the server

--- a/go-apps/meep-ctrl-engine/api/swagger.yaml
+++ b/go-apps/meep-ctrl-engine/api/swagger.yaml
@@ -757,6 +757,9 @@ definitions:
         type: "number"
         format: "double"
         description: "Packet lost (in terms of percentage) caused by the application"
+      placementId:
+        type: "string"
+        description: "Identifier used for process placement in AdvantEDGE cluster"
     description: "Application or service object"
     example: {}
   ServiceConfig:

--- a/go-apps/meep-ctrl-engine/server/README.md
+++ b/go-apps/meep-ctrl-engine/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.0.0
-- Build date: 2019-09-17T14:39:13.849-04:00
+- Build date: 2019-09-27T16:00:38.458-04:00
 
 
 ### Running the server

--- a/go-apps/meep-ctrl-engine/server/process.go
+++ b/go-apps/meep-ctrl-engine/server/process.go
@@ -71,4 +71,7 @@ type Process struct {
 
 	// Packet lost (in terms of percentage) caused by the application
 	AppPacketLoss float64 `json:"appPacketLoss,omitempty"`
+
+	// Identifier used for process placement in AdvantEDGE cluster
+	PlacementId string `json:"placementId,omitempty"`
 }

--- a/go-apps/meep-loc-serv/server/README.md
+++ b/go-apps/meep-loc-serv/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.1.1
-- Build date: 2019-09-17T14:39:23.683-04:00
+- Build date: 2019-09-27T16:00:43.365-04:00
 
 
 ### Running the server

--- a/go-apps/meep-metrics-engine/server/README.md
+++ b/go-apps/meep-metrics-engine/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.0.0
-- Build date: 2019-09-17T14:39:22.678-04:00
+- Build date: 2019-09-27T16:00:42.852-04:00
 
 
 ### Running the server

--- a/go-apps/meep-mg-manager/server/README.md
+++ b/go-apps/meep-mg-manager/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.0.0
-- Build date: 2019-09-17T14:39:18.784-04:00
+- Build date: 2019-09-27T16:00:40.859-04:00
 
 
 ### Running the server

--- a/go-apps/meep-tc-engine/api/swagger.yaml
+++ b/go-apps/meep-tc-engine/api/swagger.yaml
@@ -480,6 +480,9 @@ definitions:
         type: "number"
         format: "double"
         description: "Packet lost (in terms of percentage) caused by the application"
+      placementId:
+        type: "string"
+        description: "Identifier used for process placement in AdvantEDGE cluster"
     description: "Application or service object"
     example: {}
   ServiceConfig:

--- a/go-apps/meep-tc-engine/server/README.md
+++ b/go-apps/meep-tc-engine/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.0.0
-- Build date: 2019-09-17T14:39:16.492-04:00
+- Build date: 2019-09-27T16:00:39.729-04:00
 
 
 ### Running the server

--- a/go-apps/meep-tc-engine/server/process.go
+++ b/go-apps/meep-tc-engine/server/process.go
@@ -71,4 +71,7 @@ type Process struct {
 
 	// Packet lost (in terms of percentage) caused by the application
 	AppPacketLoss float64 `json:"appPacketLoss,omitempty"`
+
+	// Identifier used for process placement in AdvantEDGE cluster
+	PlacementId string `json:"placementId,omitempty"`
 }

--- a/go-apps/meep-virt-engine/server/chart_template.go
+++ b/go-apps/meep-virt-engine/server/chart_template.go
@@ -53,6 +53,7 @@ type DeploymentTemplate struct {
 	GpuEnabled               string
 	GpuType                  string
 	GpuCount                 string
+	PlacementId              string
 }
 
 type ServiceTemplate struct {
@@ -212,6 +213,7 @@ func populateScenarioTemplate(scenario model.Scenario) ([]helm.Chart, error) {
 							setCommand(deploymentTemplate, proc.CommandExe, proc.CommandArguments)
 							addMatchLabel(deploymentTemplate, "meepAppId: "+proc.Id)
 							addTemplateLabel(deploymentTemplate, "meepAppId: "+proc.Id)
+							deploymentTemplate.PlacementId = proc.PlacementId
 
 							// Enable Service template if present
 							if proc.ServiceConfig != nil {

--- a/go-packages/meep-ctrl-engine-client/api/swagger.yaml
+++ b/go-packages/meep-ctrl-engine-client/api/swagger.yaml
@@ -757,6 +757,9 @@ definitions:
         type: "number"
         format: "double"
         description: "Packet lost (in terms of percentage) caused by the application"
+      placementId:
+        type: "string"
+        description: "Identifier used for process placement in AdvantEDGE cluster"
     description: "Application or service object"
     example: {}
   ServiceConfig:

--- a/go-packages/meep-ctrl-engine-client/docs/Process.md
+++ b/go-packages/meep-ctrl-engine-client/docs/Process.md
@@ -24,6 +24,7 @@ Name | Type | Description | Notes
 **AppLatencyVariation** | **int32** | Latency variation in ms caused by the application | [optional] [default to null]
 **AppThroughput** | **int32** | The limit of the traffic supported by the application | [optional] [default to null]
 **AppPacketLoss** | **float64** | Packet lost (in terms of percentage) caused by the application | [optional] [default to null]
+**PlacementId** | **string** | Identifier used for process placement in AdvantEDGE cluster | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go-packages/meep-ctrl-engine-client/process.go
+++ b/go-packages/meep-ctrl-engine-client/process.go
@@ -71,4 +71,7 @@ type Process struct {
 
 	// Packet lost (in terms of percentage) caused by the application
 	AppPacketLoss float64 `json:"appPacketLoss,omitempty"`
+
+	// Identifier used for process placement in AdvantEDGE cluster
+	PlacementId string `json:"placementId,omitempty"`
 }

--- a/go-packages/meep-ctrl-engine-model/api/swagger.yaml
+++ b/go-packages/meep-ctrl-engine-model/api/swagger.yaml
@@ -544,6 +544,9 @@ definitions:
         type: number
         format: double
         description: Packet lost (in terms of percentage) caused by the application
+      placementId:
+        type: string
+        description: Identifier used for process placement in AdvantEDGE cluster
     description: Application or service object
     example: {}
   Release:

--- a/go-packages/meep-ctrl-engine-model/docs/Process.md
+++ b/go-packages/meep-ctrl-engine-model/docs/Process.md
@@ -24,6 +24,7 @@ Name | Type | Description | Notes
 **AppLatencyVariation** | **int32** | Latency variation in ms caused by the application | [optional] [default to null]
 **AppThroughput** | **int32** | The limit of the traffic supported by the application | [optional] [default to null]
 **AppPacketLoss** | **float64** | Packet lost (in terms of percentage) caused by the application | [optional] [default to null]
+**PlacementId** | **string** | Identifier used for process placement in AdvantEDGE cluster | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go-packages/meep-ctrl-engine-model/process.go
+++ b/go-packages/meep-ctrl-engine-model/process.go
@@ -71,4 +71,7 @@ type Process struct {
 
 	// Packet lost (in terms of percentage) caused by the application
 	AppPacketLoss float64 `json:"appPacketLoss,omitempty"`
+
+	// Identifier used for process placement in AdvantEDGE cluster
+	PlacementId string `json:"placementId,omitempty"`
 }

--- a/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
+++ b/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
@@ -40,6 +40,7 @@ import {
   FIELD_GROUP,
   FIELD_GPU_COUNT,
   FIELD_GPU_TYPE,
+  FIELD_PLACEMENT_ID,
   FIELD_ENV_VAR,
   FIELD_CMD,
   FIELD_CMD_ARGS,
@@ -104,6 +105,7 @@ import {
   CFG_ELEM_PROT,
   CFG_ELEM_GPU_COUNT,
   CFG_ELEM_GPU_TYPE,
+  CFG_ELEM_PLACEMENT_ID,
   CFG_ELEM_CMD,
   CFG_ELEM_ARGS,
   CFG_ELEM_EXTERNAL_CHECK,
@@ -324,7 +326,7 @@ const validateChartGroupEntry = (entry) => {
 
 const validateIngressServiceMapping = (entries) => validateEntries(validateIngressServiceMappingEntry)(entries);
 const validateEgressServiceMapping = (entries) => validateEntries(validateEgressServiceMappingEntry)(entries);
-const validateEnvironMentVariables = (entries) => validateEntries(validateEnvironmentVariableEntry)(entries);
+const validateEnvironmentVariables = (entries) => validateEntries(validateEnvironmentVariableEntry)(entries);
  
 const validateCommandArguments = () => null;
 
@@ -600,10 +602,19 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
         </Checkbox>
 
         {isExternal ? 
-          <ExternalFields 
-            onUpdate={onUpdate}
-            element={element}
-          />
+          <>
+            <ExternalFields 
+              onUpdate={onUpdate}
+              element={element}
+            />
+            <CfgTextField
+              onUpdate={onUpdate}
+              element={element}
+              label="Placement Identifier"
+              fieldName={FIELD_PLACEMENT_ID}
+              cydata={CFG_ELEM_PLACEMENT_ID}
+            />
+          </>
           :
           <>
             <Checkbox
@@ -637,13 +648,20 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
                   onUpdate={onUpdate}
                   element={element}
                   label="Environment variables"
-                  validate={validateEnvironMentVariables}
+                  validate={validateEnvironmentVariables}
                   fieldName={FIELD_ENV_VAR}
                   cydata={CFG_ELEM_ENV}
                 />
                 <CommandGroup
                   onUpdate={onUpdate}
                   element={element}
+                />
+                <CfgTextField
+                  onUpdate={onUpdate}
+                  element={element}
+                  label="Placement Identifier"
+                  fieldName={FIELD_PLACEMENT_ID}
+                  cydata={CFG_ELEM_PLACEMENT_ID}
                 />
               </>
             }
@@ -670,10 +688,19 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
         </Checkbox>
 
         {isExternal ? 
-          <ExternalFields 
-            onUpdate={onUpdate}
-            element={element}
-          />
+          <>
+            <ExternalFields 
+              onUpdate={onUpdate}
+              element={element}
+            />
+            <CfgTextField
+              onUpdate={onUpdate}
+              element={element}
+              label="Placement Identifier"
+              fieldName={FIELD_PLACEMENT_ID}
+              cydata={CFG_ELEM_PLACEMENT_ID}
+            />
+          </>
           :
           <>
             <Checkbox
@@ -711,13 +738,20 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
                   onUpdate={onUpdate}
                   element={element}
                   label="Environment variables"
-                  validate={validateEnvironMentVariables}
+                  validate={validateEnvironmentVariables}
                   fieldName={FIELD_ENV_VAR}
                   cydata={CFG_ELEM_ENV}
                 />
                 <CommandGroup
                   onUpdate={onUpdate}
                   element={element}
+                />
+                <CfgTextField
+                  onUpdate={onUpdate}
+                  element={element}
+                  label="Placement Identifier"
+                  fieldName={FIELD_PLACEMENT_ID}
+                  cydata={CFG_ELEM_PLACEMENT_ID}
                 />
               </>
             }
@@ -743,10 +777,19 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
         </Checkbox>
 
         {isExternal ? 
-          <ExternalFields 
-            onUpdate={onUpdate}
-            element={element}
-          />
+          <>
+            <ExternalFields 
+              onUpdate={onUpdate}
+              element={element}
+            />
+            <CfgTextField
+              onUpdate={onUpdate}
+              element={element}
+              label="Placement Identifier"
+              fieldName={FIELD_PLACEMENT_ID}
+              cydata={CFG_ELEM_PLACEMENT_ID}
+            />
+          </>
           :
           <>
             <Checkbox
@@ -792,13 +835,20 @@ const TypeRelatedFormFields = ({onUpdate, element}) => {
                   onUpdate={onUpdate}
                   element={element}
                   label="Environment variables"
-                  validate={validateEnvironMentVariables}
+                  validate={validateEnvironmentVariables}
                   fieldName={FIELD_ENV_VAR}
                   cydata={CFG_ELEM_ENV}
                 />
                 <CommandGroup
                   onUpdate={onUpdate}
                   element={element}
+                />
+                <CfgTextField
+                  onUpdate={onUpdate}
+                  element={element}
+                  label="Placement Identifier"
+                  fieldName={FIELD_PLACEMENT_ID}
+                  cydata={CFG_ELEM_PLACEMENT_ID}
                 />
               </>
             }

--- a/js-apps/meep-frontend/src/js/meep-constants.js
+++ b/js-apps/meep-frontend/src/js/meep-constants.js
@@ -70,6 +70,7 @@ export const CFG_ELEM_EXT_PORT = 'cfg-elem-ext-port';
 export const CFG_ELEM_PROT = 'cfg-elem-prot';
 export const CFG_ELEM_GPU_COUNT = 'cfg-elem-gpu-count';
 export const CFG_ELEM_GPU_TYPE = 'cfg-elem-gpu-type';
+export const CFG_ELEM_PLACEMENT_ID = 'cfg-elem-placement-id';
 export const CFG_ELEM_CMD = 'cfg-elem-cmd';
 export const CFG_ELEM_ARGS = 'cfg-elem-args';
 export const CFG_ELEM_EXTERNAL_CHECK = 'cfg-elem-external-check';

--- a/js-apps/meep-frontend/src/js/util/elem-utils.js
+++ b/js-apps/meep-frontend/src/js/util/elem-utils.js
@@ -63,6 +63,7 @@ export const FIELD_INGRESS_SVC_MAP = 'ingressServiceMap';
 export const FIELD_EGRESS_SVC_MAP = 'egressServiceMap';
 export const FIELD_GPU_COUNT = 'gpuCount';
 export const FIELD_GPU_TYPE = 'gpuType';
+export const FIELD_PLACEMENT_ID = 'placementId';
 export const FIELD_ENV_VAR = 'envVar';
 export const FIELD_CMD = 'cmd';
 export const FIELD_CMD_ARGS = 'cmdArgs';
@@ -134,6 +135,7 @@ export const createElem = (name) => {
   setElemFieldVal(elem, FIELD_EGRESS_SVC_MAP,         '');
   setElemFieldVal(elem, FIELD_GPU_COUNT,              '');
   setElemFieldVal(elem, FIELD_GPU_TYPE,               '');
+  setElemFieldVal(elem, FIELD_PLACEMENT_ID,           '');
   setElemFieldVal(elem, FIELD_ENV_VAR,                '');
   setElemFieldVal(elem, FIELD_CMD,                    '');
   setElemFieldVal(elem, FIELD_CMD_ARGS,               '');

--- a/js-apps/meep-frontend/src/js/util/scenario-utils.js
+++ b/js-apps/meep-frontend/src/js/util/scenario-utils.js
@@ -29,6 +29,7 @@ import {
   FIELD_GROUP,
   FIELD_GPU_COUNT,
   FIELD_GPU_TYPE,
+  FIELD_PLACEMENT_ID,
   FIELD_INGRESS_SVC_MAP,
   FIELD_EGRESS_SVC_MAP,
   FIELD_ENV_VAR,
@@ -525,7 +526,8 @@ export function createProcess(name, type, element) {
     appLatency: parseInt(DEFAULT_LATENCY_APP),
     appLatencyVariation: parseInt(DEFAULT_LATENCY_JITTER_APP),
     appThroughput: parseInt(DEFAULT_THROUGHPUT_APP),
-    appPacketLoss: parseInt(DEFAULT_PACKET_LOSS_APP)
+    appPacketLoss: parseInt(DEFAULT_PACKET_LOSS_APP),
+    placementId: null
   };
 
   if (isExternal) {
@@ -533,6 +535,7 @@ export function createProcess(name, type, element) {
       ingressServiceMap: getIngressServiceMapArray(getElemFieldVal(element, FIELD_INGRESS_SVC_MAP)),
       egressServiceMap: getEgressServiceMapArray(getElemFieldVal(element, FIELD_EGRESS_SVC_MAP))
     };
+    process.placementId = getElemFieldVal(element, FIELD_PLACEMENT_ID);
   } else if (getElemFieldVal(element, FIELD_CHART_ENABLED)) {
     process.userChartLocation = getElemFieldVal(element, FIELD_CHART_LOC);
     process.userChartAlternateValues =  getElemFieldVal(element, FIELD_CHART_VAL);
@@ -558,6 +561,7 @@ export function createProcess(name, type, element) {
       type: (getElemFieldVal(element, FIELD_GPU_TYPE) === '') ? null : getElemFieldVal(element, FIELD_GPU_TYPE).toUpperCase(),
       count: gpuCount
     };
+    process.placementId = getElemFieldVal(element, FIELD_PLACEMENT_ID);
   }
 
   process.appLatency = getElemFieldVal(element, FIELD_APP_LATENCY);
@@ -899,7 +903,8 @@ export function getElementFromScenario(scenario, elementName) {
                 setElemFieldVal(elem, FIELD_CMD, process.commandExe || '');
                 setElemFieldVal(elem, FIELD_CMD_ARGS, process.commandArguments || '');
                 setElemFieldVal(elem, FIELD_IS_EXTERNAL, process.isExternal || false);
-
+                setElemFieldVal(elem, FIELD_PLACEMENT_ID, process.placementId || '');
+                
                 if (process.serviceConfig) {
                   setElemFieldVal(elem, FIELD_PORT, process.serviceConfig.ports[0].port || '');
                   setElemFieldVal(elem, FIELD_PROTOCOL, process.serviceConfig.ports[0].protocol || '');
@@ -920,6 +925,7 @@ export function getElementFromScenario(scenario, elementName) {
                 if (process.externalConfig.egressServiceMap) {
                   setElemFieldVal(elem, FIELD_EGRESS_SVC_MAP, getEgressServiceMapStr(process.externalConfig.egressServiceMap));
                 }
+                setElemFieldVal(elem, FIELD_PLACEMENT_ID, process.placementId || '');
               }
               return elem;
             }

--- a/js-packages/meep-ctrl-engine-client/docs/Process.md
+++ b/js-packages/meep-ctrl-engine-client/docs/Process.md
@@ -24,6 +24,7 @@ Name | Type | Description | Notes
 **appLatencyVariation** | **Number** | Latency variation in ms caused by the application | [optional] 
 **appThroughput** | **Number** | The limit of the traffic supported by the application | [optional] 
 **appPacketLoss** | **Number** | Packet lost (in terms of percentage) caused by the application | [optional] 
+**placementId** | **String** | Identifier used for process placement in AdvantEDGE cluster | [optional] 
 
 
 <a name="TypeEnum"></a>

--- a/js-packages/meep-ctrl-engine-client/src/model/Process.js
+++ b/js-packages/meep-ctrl-engine-client/src/model/Process.js
@@ -69,6 +69,7 @@
 
 
 
+
   };
 
   /**
@@ -144,6 +145,9 @@
       }
       if (data.hasOwnProperty('appPacketLoss')) {
         obj['appPacketLoss'] = ApiClient.convertToType(data['appPacketLoss'], 'Number');
+      }
+      if (data.hasOwnProperty('placementId')) {
+        obj['placementId'] = ApiClient.convertToType(data['placementId'], 'String');
       }
     }
     return obj;
@@ -251,6 +255,11 @@
    * @member {Number} appPacketLoss
    */
   exports.prototype['appPacketLoss'] = undefined;
+  /**
+   * Identifier used for process placement in AdvantEDGE cluster
+   * @member {String} placementId
+   */
+  exports.prototype['placementId'] = undefined;
 
 
   /**

--- a/js-packages/meep-ctrl-engine-client/test/model/Process.spec.js
+++ b/js-packages/meep-ctrl-engine-client/test/model/Process.spec.js
@@ -182,6 +182,12 @@
       //expect(instance).to.be();
     });
 
+    it('should have the property placementId (base name: "placementId")', function() {
+      // uncomment below and update the code to test the property placementId
+      //var instane = new MeepControllerRestApi.Process();
+      //expect(instance).to.be();
+    });
+
   });
 
 }));

--- a/test/cypress/integration/tests/scenario-cfg-spec.js
+++ b/test/cypress/integration/tests/scenario-cfg-spec.js
@@ -30,6 +30,7 @@ import {
   FIELD_SVC_MAP,
   FIELD_GPU_COUNT,
   FIELD_GPU_TYPE,
+  FIELD_PLACEMENT_ID,
   FIELD_ENV_VAR,
   FIELD_CMD,
   FIELD_CMD_ARGS,
@@ -456,6 +457,7 @@ describe('Scenario Configuration', function() {
   let edgeAppEnv = 'ENV_VAR=my-env-var';
   let edgeAppCmd = '/bin/bash';
   let edgeAppArgs = '-c, export;';
+  let edgeAppPlacementId = 'node1';
 
   function addEdgeApp(name, parent) {
     click(meep.CFG_BTN_NEW_ELEM);
@@ -480,6 +482,7 @@ describe('Scenario Configuration', function() {
     type(meep.CFG_ELEM_ENV, edgeAppEnv);
     type(meep.CFG_ELEM_CMD, edgeAppCmd);
     type(meep.CFG_ELEM_ARGS, edgeAppArgs);
+    type(meep.CFG_ELEM_PLACEMENT_ID, edgeAppPlacementId);
     click(meep.MEEP_BTN_APPLY);
     verifyEnabled(meep.CFG_BTN_NEW_ELEM, true);
     verifyEnabled(meep.CFG_BTN_DEL_ELEM, false);
@@ -506,6 +509,7 @@ describe('Scenario Configuration', function() {
       assert.equal(getElemFieldVal(entry, FIELD_APP_LATENCY_VAR), appLatencyVar);
       assert.equal(getElemFieldVal(entry, FIELD_APP_PKT_LOSS), appPktLoss);
       assert.equal(getElemFieldVal(entry, FIELD_APP_THROUGPUT), appThroughput);
+      assert.equal(getElemFieldVal(entry, FIELD_PLACEMENT_ID), edgeAppPlacementId);
     });
   }
 
@@ -598,6 +602,7 @@ describe('Scenario Configuration', function() {
   let fogAppEnv = 'ENV_VAR=my-env-var';
   let fogAppCmd = '/bin/bash';
   let fogAppArgs = '-c, export;';
+  let fogAppPlacementId = 'node2';
 
   function addFogApp(name, parent) {
     click(meep.CFG_BTN_NEW_ELEM);
@@ -622,6 +627,7 @@ describe('Scenario Configuration', function() {
     type(meep.CFG_ELEM_ENV, fogAppEnv);
     type(meep.CFG_ELEM_CMD, fogAppCmd);
     type(meep.CFG_ELEM_ARGS, fogAppArgs);
+    type(meep.CFG_ELEM_PLACEMENT_ID, fogAppPlacementId);
     click(meep.MEEP_BTN_APPLY);
     verifyEnabled(meep.CFG_BTN_NEW_ELEM, true);
     verifyEnabled(meep.CFG_BTN_DEL_ELEM, false);
@@ -648,6 +654,7 @@ describe('Scenario Configuration', function() {
       assert.equal(getElemFieldVal(entry, FIELD_APP_LATENCY_VAR), appLatencyVar);
       assert.equal(getElemFieldVal(entry, FIELD_APP_PKT_LOSS), appPktLoss);
       assert.equal(getElemFieldVal(entry, FIELD_APP_THROUGPUT), appThroughput);
+      assert.equal(getElemFieldVal(entry, FIELD_PLACEMENT_ID), fogAppPlacementId);
     });
   }
 
@@ -697,6 +704,7 @@ describe('Scenario Configuration', function() {
   let ueAppEnv = 'ENV_VAR=my-env-var';
   let ueAppCmd = '/bin/bash';
   let ueAppArgs = '-c, export;';
+  let ueAppPlacementId = 'node3';
 
   // Add new ue app element
   function addUeApp(name, parent) {
@@ -718,6 +726,7 @@ describe('Scenario Configuration', function() {
     type(meep.CFG_ELEM_ENV, ueAppEnv);
     type(meep.CFG_ELEM_CMD, ueAppCmd);
     type(meep.CFG_ELEM_ARGS, ueAppArgs);
+    type(meep.CFG_ELEM_PLACEMENT_ID, ueAppPlacementId);
     click(meep.MEEP_BTN_APPLY);
     verifyEnabled(meep.CFG_BTN_NEW_ELEM, true);
     verifyEnabled(meep.CFG_BTN_DEL_ELEM, false);
@@ -740,6 +749,7 @@ describe('Scenario Configuration', function() {
       assert.equal(getElemFieldVal(entry, FIELD_APP_LATENCY_VAR), appLatencyVar);
       assert.equal(getElemFieldVal(entry, FIELD_APP_PKT_LOSS), appPktLoss);
       assert.equal(getElemFieldVal(entry, FIELD_APP_THROUGPUT), appThroughput);
+      assert.equal(getElemFieldVal(entry, FIELD_PLACEMENT_ID), ueAppPlacementId);
     });
   }
 
@@ -812,6 +822,7 @@ describe('Scenario Configuration', function() {
   let cloudAppEnv = 'ENV_VAR=my-env-var';
   let cloudAppCmd = '/bin/bash';
   let cloudAppArgs = '-c, export;';
+  let cloudAppPlacementId = '';
 
   function addCloudApp(name, parent) {
     click(meep.CFG_BTN_NEW_ELEM);
@@ -835,6 +846,7 @@ describe('Scenario Configuration', function() {
     type(meep.CFG_ELEM_ENV, cloudAppEnv);
     type(meep.CFG_ELEM_CMD, cloudAppCmd);
     type(meep.CFG_ELEM_ARGS, cloudAppArgs);
+    type(meep.CFG_ELEM_PLACEMENT_ID, cloudAppPlacementId);
     click(meep.MEEP_BTN_APPLY);
     verifyEnabled(meep.CFG_BTN_NEW_ELEM, true);
     verifyEnabled(meep.CFG_BTN_DEL_ELEM, false);
@@ -860,6 +872,7 @@ describe('Scenario Configuration', function() {
       assert.equal(getElemFieldVal(entry, FIELD_APP_LATENCY_VAR), appLatencyVar);
       assert.equal(getElemFieldVal(entry, FIELD_APP_PKT_LOSS), appPktLoss);
       assert.equal(getElemFieldVal(entry, FIELD_APP_THROUGPUT), appThroughput);
+      assert.equal(getElemFieldVal(entry, FIELD_PLACEMENT_ID), cloudAppPlacementId);
     });
   }
 


### PR DESCRIPTION
**FEATURE:**
The pod placement features allows an AdvantEDGE user to specify which node in the k8s cluster to schedule a pod on. The k8s pod scheduler currently supports node placement based on GPU resource requests and CPU + memory usage. With this new pod placement feature, the scheduler additionally uses the user-provided label to match the desired k8s node host name.

**CHANGES:**
- Added _Placement Identifier_ to Process definition in scenario model
- Regenerated swagger API code
- Updated Virt Engine service & templates to set _affinity_ with a node selection label
- Added input field in frontend to pass placement identifier to platform
  - _NOTE:_ Placement ID is set via frontend for external and frontend-defined elements only; user-chart elements must handle affinity on their own.

**TESTING:**
- Updated configuration tab test case to get & set placement ID in scenario
- Successfully ran test suite