### PR TITLE
rounding latencies

### DIFF
--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -138,8 +138,8 @@ func (u *destination) compute() (st stat) {
 	log.WithFields(log.Fields{
 		"meep.log.component":      "sidecar",
 		"meep.log.msgType":        "latency",
-		"meep.log.latency-latest": st.last / 1000000,
-		"meep.log.latency-avg":    st.mean / 1000000,
+		"meep.log.latency-latest": int(math.Round(float64(st.last) / 1000000.0)),
+		"meep.log.latency-avg":    int(math.Round(float64(st.mean) / 1000000.0)),
 		"meep.log.src":            u.hostName,
 		"meep.log.dest":           u.remoteName,
 	}).Info("Measurements log")


### PR DESCRIPTION
NA-659 : Latency less than 1ms are not sent
Latencies were using the integer part of any floating value computed in ms (so 0.9ms as well as 0.1ms became 0ms).
Rounding up the numbers is fixing this issue so that values close to the next integer better reflect the real value (0.9ms becoming 1ms, while 0.1 ms staying as 0ms). The value 0ms is a valid result, it just happens to be less common when rounding up properly, thus creating more accurate graphics.