### PR TITLE
Meepctl kibana configuration fixes

### DIFF
--- a/go-apps/meepctl/utils/kibana.go
+++ b/go-apps/meepctl/utils/kibana.go
@@ -112,9 +112,9 @@ func isKibanaReady(cobraCmd *cobra.Command) bool {
 }
 
 func uploadDefaultIndex(indexId string, cobraCmd *cobra.Command) error {
-	kibanaHost, _ := os.Hostname()
+	kibanaHost := viper.GetString("node.ip")
 	cmd := exec.Command("curl", "-vX", "POST", "http://"+kibanaHost+":32003/api/kibana/settings/defaultIndex", "-H", "Content-Type: application/json", "-H", "kbn-xsrf: true", "-d", "{\"value\": \""+indexId+"\"}")
-	out, err := cmd.CombinedOutput()
+	out, err := ExecuteCmd(cmd, cobraCmd)
 	if err != nil {
 		err = errors.New("Error sending a curl command")
 	} else {

--- a/go-apps/meepctl/utils/kibana.go
+++ b/go-apps/meepctl/utils/kibana.go
@@ -34,6 +34,8 @@ func DeployKibanaDashboards(cobraCmd *cobra.Command) {
 	gitDir := viper.GetString("meep.gitdir") + "/"
 	workdir := viper.GetString("meep.workdir")
 
+	verbose, _ := cobraCmd.Flags().GetBool("verbose")
+
 	start := time.Now()
 
 	//make sure kibana is up and ready to receive messages
@@ -72,7 +74,10 @@ func DeployKibanaDashboards(cobraCmd *cobra.Command) {
 			//defaultIndex is reserved
 			if dashboard[0] == "defaultIndex" {
 				defaultIndex := strings.TrimSpace(dashboard[1])
-				_ = uploadDefaultIndex(defaultIndex, cobraCmd)
+				err := uploadDefaultIndex(defaultIndex, cobraCmd)
+				if verbose {
+					fmt.Println(err)
+				}
 			} else {
 				if len(dashboard) >= 2 {
 					dashboard_location := strings.TrimSpace(dashboard[1])


### PR DESCRIPTION
NA-695 Meepctl cannot use os.Hostname()

On some systems (ex. VM), this command does not return a value that can be resolved. This command is currently used in meepctl config kibana command and should be replaced. The verbose was used for all commands except the first curl command which is what is failing when hostname cannot be resolved or kibana cannot be reached. The proper call to show the output were added.

Tested using valid Kibana pod (success path), not reachable host (failure path) and No Kibana pod (failure path) using verbose and not verbose. Results as expected following the fix.
