### PR TITLE
tc-engine and bwsharing concurrent updates

### DIFF
--- a/go-apps/meep-tc-engine/server/tc-engine.go
+++ b/go-apps/meep-tc-engine/server/tc-engine.go
@@ -1145,6 +1145,9 @@ func applyNetCharRules() {
 						list := dstElementPtr.FilterInfoList
 						_ = deleteFilterRule(&list[index])
 						list[index] = filterInfo //swap
+					} else if needUpdateNetChar {
+						list := dstElementPtr.FilterInfoList
+						list[index] = filterInfo //replace only
 					}
 				}
 			}

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -752,7 +752,7 @@ func cmdSetIfb(shape map[string]string) error {
 		normalDistributionStr = "distribution normal"
 	}
 	str := "tc qdisc change dev ifb" + ifbNumber + " handle 1:0 root netem delay " + delay + "ms " + delayVariation + "ms " + delayCorrelation + "% " + normalDistributionStr + " loss " + lossInteger + "." + lossFraction + "%"
-	if dataRate != "0" {
+	if dataRate != "" && dataRate != "0" {
 		str = str + " rate " + dataRate + "bit"
 	}
 	_, err := cmdExec(str)

--- a/go-packages/meep-bw-sharing/defaultBandwidthSharing.go
+++ b/go-packages/meep-bw-sharing/defaultBandwidthSharing.go
@@ -557,6 +557,7 @@ func (this *DefaultBwSharingAlgorithm) resetAllBandwidthSharingFlowMaxPlannedThr
 // updateAllBandwidthSharingFlow -
 func (this *DefaultBwSharingAlgorithm) updateAllBandwidthSharingFlow() {
 
+	changed := false
 	for _, flow := range this.BandwidthSharingFlowMap {
 
 		if flow.MaxPlannedThroughput != flow.AllocatedThroughput && flow.MaxPlannedThroughput != MAX_THROUGHPUT {
@@ -565,8 +566,11 @@ func (this *DefaultBwSharingAlgorithm) updateAllBandwidthSharingFlow() {
 			flow.AllocatedThroughputLowerBound = flow.MaxPlannedLowerBound
 			flow.AllocatedThroughputUpperBound = flow.MaxPlannedUpperBound
 			this.updateFilterCB(flow.DstNetworkElement, flow.SrcNetworkElement, flow.AllocatedThroughput)
-			this.applyFilterCB()
+			changed = true
 		}
+	}
+	if changed {
+		this.applyFilterCB()
 	}
 }
 


### PR DESCRIPTION
2 issues:

1) When updating the network characteristic through a network event, both tc-engine and bw-sharing process the new scenario. Bw-sharing then sets the new throughput through the tc-engine but uses a structure for the other filter information that was not updated properly, thus creating a discrepancy. Wrong value is used to populate Redis DB that then creates wrong flow rules (actually updating the throughput values, but not the other netChar values such as latency)

2) If dataRate is not present (attribute in the DB used to populate the throughput limitation in the sidecar), the whole flow rule is not populated by the sidecar.