### PR TITLE
packet loss computation fix in segment algo

### DIFF
--- a/go-packages/meep-net-char-mgr/algo-segment.go
+++ b/go-packages/meep-net-char-mgr/algo-segment.go
@@ -815,7 +815,9 @@ func (algo *SegmentAlgorithm) reCalculateNetChar() {
 				//first time it finds a value, it applies it directly
 				flow.ComputedPacketLoss = segment.ConfiguredNetChar.PacketLoss
 			} else {
-				flow.ComputedPacketLoss += (flow.ComputedPacketLoss * (1 - segment.ConfiguredNetChar.PacketLoss))
+				if segment.ConfiguredNetChar.PacketLoss != 0 {
+					flow.ComputedPacketLoss += (flow.ComputedPacketLoss * (1 - segment.ConfiguredNetChar.PacketLoss))
+				}
 			}
 		}
 		if algo.Config.LogVerbose {


### PR DESCRIPTION
Packet loss computation not accurate in segment algorithm

- Previous value of Packet loss is added over current value if packet loss of current segment is 0 but previous one wasn't.

Testing
- verified packet loss correctly applied
