### PR TITLE
sidecar optimization - evicted pods - termination optimization

### DIFF
--- a/go-apps/meep-mon-engine/mon-engine.go
+++ b/go-apps/meep-mon-engine/mon-engine.go
@@ -256,7 +256,10 @@ func addOrUpdateEntryInDB(monEngineInfo MonEngineInfo) {
 	key := moduleMonEngine + ":MO-" + monEngineInfo.MeepOrigin + ":MS-" + monEngineInfo.MeepScenario + ":MA-" + monEngineInfo.MeepApp + ":" + monEngineInfo.PodName
 
 	// Set rule information in DB
-	_ = rc.SetEntry(key, fields)
+	err := rc.SetEntry(key, fields)
+	if err != nil {
+		log.Error("Entry could not be updated in DB for ", monEngineInfo.MeepApp, ": ", err)
+	}
 }
 
 func deleteEntryInDB(monEngineInfo MonEngineInfo) {
@@ -265,7 +268,10 @@ func deleteEntryInDB(monEngineInfo MonEngineInfo) {
 	key := moduleMonEngine + ":MO-" + monEngineInfo.MeepOrigin + ":MS-" + monEngineInfo.MeepScenario + ":MA-" + monEngineInfo.MeepApp + ":" + monEngineInfo.PodName
 
 	// Set rule information in DB
-	_ = rc.DelEntry(key)
+	err := rc.DelEntry(key)
+	if err != nil {
+		log.Error("Entry could not be deleted in DB for ", monEngineInfo.MeepApp, ": ", err)
+	}
 }
 
 func k8sConnect() (err error) {

--- a/go-apps/meep-tc-sidecar/Dockerfile
+++ b/go-apps/meep-tc-sidecar/Dockerfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 FROM debian:9.6-slim
-RUN apt-get update && apt-get install -y iputils-ping iproute2 iptables conntrack
+RUN apt-get update && apt-get install -y iputils-ping iproute2 iptables conntrack net-tools
 COPY ./meep-tc-sidecar /meep-tc-sidecar
 ENTRYPOINT ["/meep-tc-sidecar"]

--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	//redis "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis"
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 	ms "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-metric-store"
 )

--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	//redis "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis"
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 	ms "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-metric-store"
 )
@@ -163,26 +164,16 @@ func (u *destination) compute() (st stat) {
 	return
 }
 
-func (u *destination) processRxTx() {
+func (u *destination) processRxTx(ifbStatsStr string) {
 
-	// Retrieve ifb statistics
-	// ex :qdisc netem 1: root refcnt 2 limit 1000 delay 100.0ms 10.0ms 50% loss 50% rate 2Mbit\n
-	//                    Sent 756 bytes 8 pkt (dropped 4, overlimits 0 requeues 0)
-	str := "tc -s qdisc show dev ifb" + u.ifbNumber
-	out, err := cmdExec(str)
-	if err != nil {
-		log.Error("tc -s qdisc show dev ifb", u.ifbNumber)
-		log.Error(err)
-		return
-	}
-
-	// Parse ifb stats
+	// Retrieve ifb statistics from passed string
 	// NOTE: we have to read the ifbStats from the back since based on the results are always at
 	//       the end but the characteristic may be different (no pkt loss, no normal distribution, etc)
-	ifbStats := strings.Split(out, " ")
+	ifbStats := strings.Split(ifbStatsStr, " ")
+
 	var curRxBytes int
-	if len(ifbStats) > 20 {
-		curRxBytes, _ = strconv.Atoi(ifbStats[len(ifbStats)-17])
+	if len(ifbStats) >= 13 {
+		curRxBytes, _ = strconv.Atoi(ifbStats[len(ifbStats)-11])
 	} else {
 		log.Error("Error in the ifb statistics output: ", ifbStats)
 	}
@@ -206,35 +197,25 @@ func (u *destination) processRxTx() {
 	var tputStats = make(map[string]interface{})
 	tputStats[u.remoteName] = tput
 	key := moduleMetrics + ":" + PodName + ":throughput"
+
 	if rc.EntryExists(key) {
 		_ = rc.SetEntry(key, tputStats)
 	}
 }
 
-func (u *destination) logRxTx() {
+func (u *destination) logRxTx(ifbStatsStr string) {
 
-	// Retrieve ifb statistics
-	// ex :qdisc netem 1: root refcnt 2 limit 1000 delay 100.0ms 10.0ms 50% loss 50% rate 2Mbit\n
-	//                    Sent 756 bytes 8 pkt (dropped 4, overlimits 0 requeues 0)
-	str := "tc -s qdisc show dev ifb" + u.ifbNumber
-	out, err := cmdExec(str)
-	if err != nil {
-		log.Error("tc -s qdisc show dev ifb", u.ifbNumber)
-		log.Error(err)
-		return
-	}
-
-	// Parse ifb stats
+	// Retrieve ifb statistics from passed string
 	// NOTE: we have to read the ifbStats from the back since based on the results are always at
 	//       the end but the characteristic may be different (no pkt loss, no normal distribution, etc)
-	ifbStats := strings.Split(out, " ")
+	ifbStats := strings.Split(ifbStatsStr, " ")
 	var curRxPkt int
 	var curRxPktDrop int
 	var curRxBytes int
-	if len(ifbStats) > 20 {
-		curRxPkt, _ = strconv.Atoi(ifbStats[len(ifbStats)-15])
-		curRxPktDrop, _ = strconv.Atoi(ifbStats[len(ifbStats)-12][:len(ifbStats[len(ifbStats)-12])-1])
-		curRxBytes, _ = strconv.Atoi(ifbStats[len(ifbStats)-17])
+	if len(ifbStats) >= 13 {
+		curRxPkt, _ = strconv.Atoi(ifbStats[len(ifbStats)-9])
+		curRxPktDrop, _ = strconv.Atoi(ifbStats[len(ifbStats)-6][:len(ifbStats[len(ifbStats)-6])-1])
+		curRxBytes, _ = strconv.Atoi(ifbStats[len(ifbStats)-11])
 	} else {
 		log.Error("Error in the ifb statistics output: ", ifbStats)
 	}
@@ -277,7 +258,8 @@ func (u *destination) logRxTx() {
 	semLatencyMap.Unlock()
 	metric.UlTput = tput
 	metric.UlLoss = loss
-	err = metricStore.SetCachedNetworkMetric(metric)
+
+	err := metricStore.SetCachedNetworkMetric(metric)
 	if err != nil {
 		log.Error("Failed to set network metric")
 	}

--- a/go-apps/meep-virt-engine/helm/delete.go
+++ b/go-apps/meep-virt-engine/helm/delete.go
@@ -32,8 +32,8 @@ func deleteReleases(charts []Chart) error {
 
 func deleteRelease(chart Chart) {
 	var cmd = exec.Command("helm", "delete", chart.ReleaseName, "--purge")
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error(err)
+		log.Error("Chart couldn't be released: ", string(out), "---", err)
 	}
 }

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -19,6 +19,7 @@ package server
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/InterDigitalInc/AdvantEDGE/go-apps/meep-virt-engine/helm"
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
@@ -28,6 +29,7 @@ import (
 
 const moduleName string = "meep-virt-engine"
 const redisAddr string = "localhost:30379"
+const retryTimerDuration = 10000
 
 var watchdogClient *watchdog.Pingee
 var activeModel *mod.Model
@@ -78,8 +80,28 @@ func eventHandler(channel string, payload string) {
 
 func processActiveScenarioUpdate(event string) {
 	if event == mod.EventTerminate {
-		terminateScenario(activeScenarioName)
-		activeScenarioName = ""
+
+		//process right away and start a ticker to retry until everything is deleted
+		_, _ = terminateScenario(activeScenarioName)
+
+		//starts a ticker
+		ticker := time.NewTicker(retryTimerDuration * time.Millisecond)
+
+		go func() {
+			for range ticker.C {
+
+				err, chartsToDelete := terminateScenario(activeScenarioName)
+
+				if err == nil && chartsToDelete == 0 {
+					activeScenarioName = ""
+					ticker.Stop()
+					return
+				} else {
+					//stay in the deletion process until everything is cleared
+					log.Info("Number of charts remaining to be deleted: ", chartsToDelete)
+				}
+			}
+		}()
 	} else if event == mod.EventActivate {
 		// Cache name for later deletion
 		activeScenarioName = activeModel.GetScenarioName()
@@ -97,33 +119,42 @@ func activateScenario() {
 	}
 }
 
-func terminateScenario(name string) {
+func terminateScenario(name string) (error, int) {
 	if name == "" {
-		return
+		return nil, 0
 	}
 	// Retrieve list of releases
-	rels, _ := helm.GetReleasesName()
-	var toDelete []helm.Chart
-	for _, rel := range rels {
-		if strings.Contains(rel.Name, name) {
-			// just keep releases related to the current scenario
-			var c helm.Chart
-			c.ReleaseName = rel.Name
-			toDelete = append(toDelete, c)
+	chartsToDelete := 0
+	rels, err := helm.GetReleasesName()
+	if err == nil {
+		var toDelete []helm.Chart
+		for _, rel := range rels {
+			if strings.Contains(rel.Name, name) {
+				// just keep releases related to the current scenario
+				var c helm.Chart
+				c.ReleaseName = rel.Name
+				toDelete = append(toDelete, c)
+			}
+		}
+
+		// Delete releases
+		chartsToDelete = len(toDelete)
+
+		if chartsToDelete > 0 {
+			err := helm.DeleteReleases(toDelete)
+			chartsToDelete = len(toDelete)
+			if err != nil {
+				log.Debug("Releases deletion failure:", err)
+			}
+		}
+
+		// Then delete charts
+		homePath := os.Getenv("HOME")
+		path := homePath + "/.meep/active/" + name
+		if _, err := os.Stat(path); err == nil {
+			log.Debug("Removing charts ", path)
+			os.RemoveAll(path)
 		}
 	}
-
-	// Delete releases
-	if len(toDelete) > 0 {
-		err := helm.DeleteReleases(toDelete)
-		log.Debug(err)
-	}
-
-	// Then delete charts
-	homePath := os.Getenv("HOME")
-	path := homePath + "/.meep/active/" + name
-	if _, err := os.Stat(path); err == nil {
-		log.Debug("Removing charts ", path)
-		os.RemoveAll(path)
-	}
+	return err, chartsToDelete
 }

--- a/go-packages/meep-model/model.go
+++ b/go-packages/meep-model/model.go
@@ -204,17 +204,18 @@ func (m *Model) Activate() (err error) {
 // Deactivate - Remove the active scenario
 func (m *Model) Deactivate() (err error) {
 	if m.Active {
-		m.Active = false
 		err = m.rc.JSONDelEntry(m.activeKey, ".")
 		if err != nil {
-			log.Error(err.Error())
+			log.Error("Failed to delete entry: ", err.Error())
 			return err
 		}
+
 		err = m.rc.Publish(m.ActiveChannel, EventTerminate)
 		if err != nil {
-			log.Error(err.Error())
+			log.Error("Failed to publish: ", err.Error())
 			return err
 		}
+		m.Active = false
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes:
Termination stabilization to prevent non-terminating pods
TCP connections to DB from sidecar optimization
Evicted pods not impacting the state of the frontend (green light)

CHANGES:
Virtual Engine:
Retry mechanism added for sending helm commands to delete deployments
Ctrl Engine:
Handling nil active scenario if it couldn't be allocated
Filtering returned core pods states when queried to keep Running ones as a priority
Sidecar:
Using single thread rather then multiple ones to write to Redis
Invoking all ifbs stats and going through the result at once rather than per ifb

TESTING:
Unit tests PASS
Cypress tests PASS