### PR TITLE
Fix for concurrent map access crash in TC sidecar

### DIFF
--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -143,11 +143,11 @@ func (u *destination) compute() (st stat) {
 	lat := int32(math.Round(float64(st.last) / 1000000.0))
 	mean := int32(math.Round(float64(st.mean) / 1000000.0))
 
-	//string for mapping src:dest
-	mapName := u.hostName + ":" + u.remoteName
-	semLatencyMap <- 1
-	latestLatencyResultsMap[mapName] = lat
-	<-semLatencyMap
+	// Store latency metric
+	err := metricStore.SetLatencyMetric(u.hostName, u.remoteName, lat)
+	if err != nil {
+		log.Error("Failed to set latency metric")
+	}
 
 	// Log measurment
 	log.WithFields(log.Fields{
@@ -266,16 +266,10 @@ func (u *destination) logRxTx() {
 	u.prevRxLog.rxPkt = curRxPkt
 	u.prevRxLog.rxPktDrop = curRxPktDrop
 
-	// Store traffic metric
+	// Store latency metric
 	err = metricStore.SetTrafficMetric(u.remoteName, PodName, tput, loss)
 	if err != nil {
 		log.Error("Failed to set traffic metric")
-	}
-	// Store latency metric
-	srcDest := u.hostName + ":" + u.remoteName
-	err = metricStore.SetLatencyMetric(u.hostName, u.remoteName, latestLatencyResultsMap[srcDest])
-	if err != nil {
-		log.Error("Failed to set latency metric")
 	}
 
 	log.WithFields(log.Fields{

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -70,7 +70,6 @@ type podShortElement struct {
 }
 
 var sem = make(chan int, 1)
-var semLatencyMap = make(chan int, 1)
 
 var opts = struct {
 	timeout         time.Duration
@@ -110,7 +109,6 @@ var serviceChains = map[string]string{}
 var ifbs = map[string]string{}
 var filters = map[string]string{}
 var netcharMap = map[string]*NetChar{}
-var latestLatencyResultsMap = map[string]int32{}
 
 var measurementsRunning = false
 var flushRequired = false
@@ -544,7 +542,6 @@ func callPing() {
 
 func workLatency() {
 	for {
-
 		for i, u := range opts.dests {
 			//starting 2 threads, one for the pings, one for the computing part
 			go func(u *destination, i int) {


### PR DESCRIPTION
Crashing pod caused by mutex not protecting all places a global latency array is invoked