### PR TITLE
logs optimizations

### DIFF
--- a/go-apps/meep-ctrl-engine/main.go
+++ b/go-apps/meep-ctrl-engine/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	log.MeepJSONLogInit("meep-ctrl-engine")
+	log.MeepTextLogInit("meep-ctrl-engine")
 }
 
 func main() {

--- a/go-apps/meep-ctrl-engine/server/logger.go
+++ b/go-apps/meep-ctrl-engine/server/logger.go
@@ -25,9 +25,10 @@
 package server
 
 import (
-	"log"
 	"net/http"
 	"time"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
 func Logger(inner http.Handler, name string) http.Handler {
@@ -36,11 +37,10 @@ func Logger(inner http.Handler, name string) http.Handler {
 
 		inner.ServeHTTP(w, r)
 
-		log.Printf(
-			"%s %s %s %s",
-			r.Method,
-			r.RequestURI,
-			name,
+		log.Debug(
+			r.Method, " ",
+			r.RequestURI, " ",
+			name, " ",
 			time.Since(start),
 		)
 	})

--- a/go-apps/meep-ctrl-engine/server/routers.go
+++ b/go-apps/meep-ctrl-engine/server/routers.go
@@ -29,8 +29,6 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
-
 	"github.com/gorilla/mux"
 )
 
@@ -46,7 +44,7 @@ type Routes []Route
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range routes {
-		var handler http.Handler = log.HTTP(route.HandlerFunc, route.Name)
+		var handler http.Handler = Logger(route.HandlerFunc, route.Name)
 
 		router.
 			Methods(route.Method).

--- a/go-apps/meep-ctrl-engine/server/routers.go
+++ b/go-apps/meep-ctrl-engine/server/routers.go
@@ -29,6 +29,8 @@ import (
 	"net/http"
 	"strings"
 
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+
 	"github.com/gorilla/mux"
 )
 
@@ -44,8 +46,7 @@ type Routes []Route
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range routes {
-		var handler http.Handler = route.HandlerFunc
-		//		handler = Logger(handler, route.Name)
+		var handler http.Handler = log.HTTP(route.HandlerFunc, route.Name)
 
 		router.
 			Methods(route.Method).

--- a/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
+++ b/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
@@ -76,11 +76,10 @@ func eventHandler(channel string, payload string) {
 
 	// MEEP Ctrl Engine active scenario update Channel
 	case mod.ActiveScenarioEvents:
-		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents)
+		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents, " payload: ", payload)
 		processActiveScenarioUpdate()
-
 	default:
-		log.Warn("Unsupported channel")
+		log.Warn("Unsupported channel", " payload: ", payload)
 	}
 }
 

--- a/go-apps/meep-loc-serv/server/logger.go
+++ b/go-apps/meep-loc-serv/server/logger.go
@@ -25,9 +25,10 @@
 package server
 
 import (
-	"log"
 	"net/http"
 	"time"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
 func Logger(inner http.Handler, name string) http.Handler {
@@ -36,11 +37,10 @@ func Logger(inner http.Handler, name string) http.Handler {
 
 		inner.ServeHTTP(w, r)
 
-		log.Printf(
-			"%s %s %s %s",
-			r.Method,
-			r.RequestURI,
-			name,
+		log.Debug(
+			r.Method, " ",
+			r.RequestURI, " ",
+			name, " ",
 			time.Since(start),
 		)
 	})

--- a/go-apps/meep-metrics-engine/server/logger.go
+++ b/go-apps/meep-metrics-engine/server/logger.go
@@ -25,9 +25,10 @@
 package server
 
 import (
-	"log"
 	"net/http"
 	"time"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
 func Logger(inner http.Handler, name string) http.Handler {
@@ -36,11 +37,10 @@ func Logger(inner http.Handler, name string) http.Handler {
 
 		inner.ServeHTTP(w, r)
 
-		log.Printf(
-			"%s %s %s %s",
-			r.Method,
-			r.RequestURI,
-			name,
+		log.Debug(
+			r.Method, " ",
+			r.RequestURI, " ",
+			name, " ",
 			time.Since(start),
 		)
 	})

--- a/go-apps/meep-metrics-engine/server/v2/metrics-engine.go
+++ b/go-apps/meep-metrics-engine/server/v2/metrics-engine.go
@@ -115,10 +115,10 @@ func eventHandler(channel string, payload string) {
 
 	// MEEP Ctrl Engine active scenario update event
 	case mod.ActiveScenarioEvents:
+		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents, " payload: ", payload)
 		processActiveScenarioUpdate(payload)
-
 	default:
-		log.Warn("Unsupported channel event: ", channel)
+		log.Warn("Unsupported channel event: ", channel, " payload: ", payload)
 	}
 }
 

--- a/go-apps/meep-mg-manager/server/logger.go
+++ b/go-apps/meep-mg-manager/server/logger.go
@@ -25,9 +25,10 @@
 package server
 
 import (
-	"log"
 	"net/http"
 	"time"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
 func Logger(inner http.Handler, name string) http.Handler {
@@ -36,11 +37,10 @@ func Logger(inner http.Handler, name string) http.Handler {
 
 		inner.ServeHTTP(w, r)
 
-		log.Printf(
-			"%s %s %s %s",
-			r.Method,
-			r.RequestURI,
-			name,
+		log.Debug(
+			r.Method, " ",
+			r.RequestURI, " ",
+			name, " ",
 			time.Since(start),
 		)
 	})

--- a/go-apps/meep-mg-manager/server/mg-manager.go
+++ b/go-apps/meep-mg-manager/server/mg-manager.go
@@ -196,11 +196,10 @@ func eventHandler(channel string, payload string) {
 
 	// MEEP Ctrl Engine active scenario update Channel
 	case mod.ActiveScenarioEvents:
-		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents)
+		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents, " payload: ", payload)
 		processActiveScenarioUpdate()
-
 	default:
-		log.Warn("Unsupported channel")
+		log.Warn("Unsupported channel", " payload: ", payload)
 	}
 }
 
@@ -640,6 +639,7 @@ func applyMgSvcMapping() {
 	}
 
 	// Publish Edge LB rules update
+	log.Debug("TX-MSG [", channelMgManagerLb, "] ", "")
 	_ = mgm.lbRulesStore.rc.Publish(channelMgManagerLb, "")
 }
 

--- a/go-apps/meep-mon-engine/mon-engine.go
+++ b/go-apps/meep-mon-engine/mon-engine.go
@@ -113,23 +113,23 @@ func connectToAPISvr() (*kubernetes.Clientset, error) {
 func printfMonEngineInfo(monEngineInfo MonEngineInfo, reason int) {
 
 	log.Debug("Monitoring Engine info *** ", pod_event_str[reason], " *** ",
-		"pod name : ", monEngineInfo.PodName,
-		"namespace : ", monEngineInfo.Namespace,
-		"meepApp : ", monEngineInfo.MeepApp,
-		"meepOrigin : ", monEngineInfo.MeepOrigin,
-		"meepScenario : ", monEngineInfo.MeepScenario,
-		"phase : ", monEngineInfo.Phase,
-		"podInitialized : ", monEngineInfo.PodInitialized,
-		"podUnschedulable : ", monEngineInfo.PodUnschedulable,
-		"podScheduled : ", monEngineInfo.PodScheduled,
-		"podReady : ", monEngineInfo.PodReady,
-		"podConditionError : ", monEngineInfo.PodConditionError,
-		"ContainerStatusesMsg : ", monEngineInfo.ContainerStatusesMsg,
-		"NbOkContainers : ", monEngineInfo.NbOkContainers,
-		"NbTotalContainers : ", monEngineInfo.NbTotalContainers,
-		"NbPodRestart : ", monEngineInfo.NbPodRestart,
-		"LogicalState : ", monEngineInfo.LogicalState,
-		"StartTime : ", monEngineInfo.StartTime)
+		" pod name : ", monEngineInfo.PodName,
+		" namespace : ", monEngineInfo.Namespace,
+		" meepApp : ", monEngineInfo.MeepApp,
+		" meepOrigin : ", monEngineInfo.MeepOrigin,
+		" meepScenario : ", monEngineInfo.MeepScenario,
+		" phase : ", monEngineInfo.Phase,
+		" podInitialized : ", monEngineInfo.PodInitialized,
+		" podUnschedulable : ", monEngineInfo.PodUnschedulable,
+		" podScheduled : ", monEngineInfo.PodScheduled,
+		" podReady : ", monEngineInfo.PodReady,
+		" podConditionError : ", monEngineInfo.PodConditionError,
+		" ContainerStatusesMsg : ", monEngineInfo.ContainerStatusesMsg,
+		" NbOkContainers : ", monEngineInfo.NbOkContainers,
+		" NbTotalContainers : ", monEngineInfo.NbTotalContainers,
+		" NbPodRestart : ", monEngineInfo.NbPodRestart,
+		" LogicalState : ", monEngineInfo.LogicalState,
+		" StartTime : ", monEngineInfo.StartTime)
 }
 
 func processEvent(obj interface{}, reason int) {

--- a/go-apps/meep-tc-engine/main.go
+++ b/go-apps/meep-tc-engine/main.go
@@ -27,7 +27,8 @@ import (
 
 func init() {
 	// Log as JSON instead of the default ASCII formatter.
-	log.MeepJSONLogInit("meep-tc-engine")
+	//log.MeepJSONLogInit("meep-tc-engine")
+	log.MeepTextLogInit("meep-tc-engine")
 }
 
 func main() {

--- a/go-apps/meep-tc-engine/tc-engine.go
+++ b/go-apps/meep-tc-engine/tc-engine.go
@@ -275,10 +275,10 @@ func eventHandler(channel string, payload string) {
 	// Handle Message according to Rx Channel
 	switch channel {
 	case mod.ActiveScenarioEvents:
-		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents)
+		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents, " payload: ", payload)
 		processActiveScenarioUpdate()
 	case channelMgManagerLb:
-		log.Debug("Event received on channel: ", channelMgManagerLb)
+		log.Debug("Event received on channel: ", channelMgManagerLb, " payload: ", payload)
 		processMgSvcMapUpdate()
 	default:
 		log.Warn("Unsupported channel")
@@ -347,6 +347,7 @@ func processMgSvcMapUpdate() {
 	applyMgSvcMapping()
 
 	// Publish update to TC Sidecars for enforcement
+	log.Debug("TX-MSG [", channelTcLb, "] ", "")
 	_ = tce.netCharStore.rc.Publish(channelTcLb, "")
 }
 
@@ -570,6 +571,7 @@ func updateComplete() {
 
 	// Publish update to TC Sidecars for enforcement
 	transactionIdStr := strconv.Itoa(tce.nextTransactionId)
+	log.Debug("TX-MSG [", channelTcNet, "] ", transactionIdStr)
 	_ = tce.netCharStore.rc.Publish(channelTcNet, transactionIdStr)
 	tce.nextTransactionId++
 	mutex.Unlock()

--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -142,23 +142,12 @@ func (u *destination) compute() (st stat) {
 
 	// Format latency measurement
 	lat := int32(math.Round(float64(st.last) / 1000000.0))
-	mean := int32(math.Round(float64(st.mean) / 1000000.0))
 
 	//string for mapping src:dest
 	mapName := u.hostName + ":" + u.remoteName
 	semLatencyMap.Lock()
 	latestLatencyResultsMap[mapName] = lat
 	semLatencyMap.Unlock()
-
-	// Log measurment
-	log.WithFields(log.Fields{
-		"meep.log.component":      "sidecar",
-		"meep.log.msgType":        "latency",
-		"meep.log.latency-latest": lat,
-		"meep.log.latency-avg":    mean,
-		"meep.log.src":            u.hostName,
-		"meep.log.dest":           u.remoteName,
-	}).Info("Measurements log")
 
 	return
 }
@@ -230,7 +219,6 @@ func (u *destination) logRxTx(ifbStatsStr string) {
 	if totalRxPkt > 0 {
 		loss = (float64(rxPktDrop) / float64(totalRxPkt)) * 100
 	}
-	lossStr := strconv.FormatFloat(loss, 'f', 3, 64)
 
 	// Calculate throughput in Mbps
 	var tput float64
@@ -239,7 +227,6 @@ func (u *destination) logRxTx(ifbStatsStr string) {
 		timeDiff := curTime.Sub(u.prevRxLog.time).Seconds()
 		tput = (8 * float64(rxBytes) / timeDiff) / 1000000
 	}
-	tputStr := strconv.FormatFloat(tput, 'f', 3, 64) + " Mbps"
 
 	// Store latest values for next calculation
 	u.prevRxLog.time = curTime
@@ -263,16 +250,4 @@ func (u *destination) logRxTx(ifbStatsStr string) {
 		log.Error("Failed to set network metric")
 	}
 
-	log.WithFields(log.Fields{
-		"meep.log.component":     "sidecar",
-		"meep.log.msgType":       "ingressPacketStats",
-		"meep.log.src":           u.remoteName,
-		"meep.log.dest":          u.hostName,
-		"meep.log.rx":            rxPkt,
-		"meep.log.rxd":           rxPktDrop,
-		"meep.log.rxBytes":       rxBytes,
-		"meep.log.throughput":    tput,
-		"meep.log.throughputStr": tputStr,
-		"meep.log.packet-loss":   lossStr,
-	}).Info("Measurements log")
 }

--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -152,7 +152,7 @@ func (u *destination) compute() (st stat) {
 	return
 }
 
-func (u *destination) processRxTx(ifbStatsStr string) {
+func (u *destination) processRxTx(ifbStatsStr string) float64 {
 
 	// Retrieve ifb statistics from passed string
 	// NOTE: we have to read the ifbStats from the back since based on the results are always at
@@ -181,14 +181,7 @@ func (u *destination) processRxTx(ifbStatsStr string) {
 	u.prevRx.time = curTime
 	u.prevRx.rxBytes = curRxBytes
 
-	// Store throughput metric if entry exists
-	var tputStats = make(map[string]interface{})
-	tputStats[u.remoteName] = tput
-	key := moduleMetrics + ":" + PodName + ":throughput"
-
-	if rc.EntryExists(key) {
-		_ = rc.SetEntry(key, tputStats)
-	}
+	return tput
 }
 
 func (u *destination) logRxTx(ifbStatsStr string) {

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -125,7 +125,6 @@ var metricStore *ms.MetricStore
 
 const DEFAULT_SIDECAR_DB = 0
 
-var nbAppliedSetIfbs = 0
 var nbAppliedOperations = 0
 
 // Run - MEEP Sidecar execution
@@ -693,7 +692,6 @@ func createPingHandler(key string, fields map[string]string, userData interface{
 
 func createIfbs() error {
 	keyName := moduleTcEngine + ":" + typeNet + ":" + PodName + ":shape*"
-	nbAppliedSetIfbs = 0
 	err := rc.ForEachEntry(keyName, createIfbsHandler, nil)
 	if err != nil {
 		return err
@@ -703,19 +701,15 @@ func createIfbs() error {
 
 func createIfbsHandler(key string, fields map[string]string, userData interface{}) error {
 	ifbNumber := fields["ifb_uniqueId"]
-	applied := false
 	_, exists := ifbs[ifbNumber]
 	if !exists {
 		_ = cmdCreateIfb(fields)
 		ifbs[ifbNumber] = ifbNumber
-		applied, _ = cmdSetIfb(fields)
+		_, _ = cmdSetIfb(fields)
 	} else {
-		applied, _ = cmdSetIfb(fields)
+		_, _ = cmdSetIfb(fields)
 	}
 
-	if applied {
-		nbAppliedSetIfbs++
-	}
 	return nil
 }
 

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -71,10 +71,10 @@ func eventHandler(channel string, payload string) {
 
 	// MEEP Ctrl Engine active scenario update event
 	case mod.ActiveScenarioEvents:
+		log.Debug("Event received on channel: ", channel, " payload: ", payload)
 		processActiveScenarioUpdate(payload)
-
 	default:
-		log.Warn("Unsupported channel event: ", channel)
+		log.Warn("Unsupported channel event: ", channel, " payload: ", payload)
 	}
 }
 

--- a/go-apps/meep-webhook/webhook.go
+++ b/go-apps/meep-webhook/webhook.go
@@ -83,12 +83,11 @@ func eventHandler(channel string, payload string) {
 	// MEEP Ctrl Engine active scenario update Channel
 	// case channelCtrlActive:
 	case model.ActiveChannel:
-		log.Debug("Event received on channel: ", model.ActiveChannel)
+		log.Debug("Event received on channel: ", model.ActiveChannel, " payload: ", payload)
 		// processActiveScenarioUpdate()
 		activeScenarioName = model.GetScenarioName()
-
 	default:
-		log.Warn("Unsupported channel")
+		log.Warn("Unsupported channel", " payload: ", payload)
 	}
 }
 

--- a/go-packages/meep-logger/logger.go
+++ b/go-packages/meep-logger/logger.go
@@ -17,11 +17,10 @@
 package logger
 
 import (
-	"net/http"
-	"time"
-	"runtime"
-	"path"
 	"fmt"
+	"path"
+	"runtime"
+
 	logrus "github.com/sirupsen/logrus"
 )
 
@@ -30,15 +29,19 @@ var componentName string
 type Fields map[string]interface{}
 
 func MeepTextLogInit(name string) {
+	Formatter := new(logrus.TextFormatter)
+	Formatter.TimestampFormat = "2006-01-02T15:04:05.999999999Z07:00"
+	Formatter.FullTimestamp = true
+	logrus.SetFormatter(Formatter)
 	//logrus.SetLevel(logrus.TraceLevel)
-        logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.DebugLevel)
 	componentName = name
 }
 
 func MeepJSONLogInit(name string) {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
 	//logrus.SetLevel(logrus.TraceLevel)
-        logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetLevel(logrus.DebugLevel)
 	componentName = name
 }
 
@@ -47,87 +50,58 @@ func MeepJSONLogInit(name string) {
 func getLogCaller() string {
 	_, file, line, _ := runtime.Caller(2)
 
-        location := fmt.Sprintf("%v:%v", path.Base(file), line)
+	location := fmt.Sprintf("%v:%v", path.Base(file), line)
 	return location
 }
 
 func Info(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.time": time.Now().String(),
 	}).Info(args...)
 }
 
 func Debug(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.from": getLogCaller(),
-		"meep.time": time.Now().String(),
+		"meep.from":      getLogCaller(),
 	}).Debug(args...)
 }
 
 func Trace(args ...interface{}) {
-        logrus.WithFields(logrus.Fields{
-                "meep.component": componentName,
-                "meep.from": getLogCaller(),
-                "meep.time": time.Now().String(),
-        }).Trace(args...)
+	logrus.WithFields(logrus.Fields{
+		"meep.component": componentName,
+		"meep.from":      getLogCaller(),
+	}).Trace(args...)
 }
 
 func Warn(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.from": getLogCaller(),
-		"meep.time": time.Now().String(),
+		"meep.from":      getLogCaller(),
 	}).Warn(args...)
 }
 
 func Error(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.from": getLogCaller(),
-		"meep.time": time.Now().String(),
+		"meep.from":      getLogCaller(),
 	}).Error(args...)
 }
 
 func Panic(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.from": getLogCaller(),
-		"meep.time": time.Now().String(),
+		"meep.from":      getLogCaller(),
 	}).Panic(args...)
 }
 
 func Fatal(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
-		"meep.from": getLogCaller(),
-		"meep.time": time.Now().String(),
+		"meep.from":      getLogCaller(),
 	}).Fatal(args...)
 }
 
 func WithFields(fields Fields) *logrus.Entry {
 	return logrus.WithFields(logrus.Fields(fields))
-}
-
-func httpLog(args ...interface{}) {
-        logrus.WithFields(logrus.Fields{
-                "meep.component": componentName,
-                "meep.from": getLogCaller(),
-                "meep.time": time.Now().String(),
-        }).Debug(args...)
-}
-
-func HTTP(inner http.Handler, name string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-
-		inner.ServeHTTP(w, r)
-
-		httpLog(
-			r.Method,
-			" ", r.RequestURI,
-			" apiFct: ", name,
-			" execTime: ", time.Since(start))
-	})
 }

--- a/go-packages/meep-logger/logger.go
+++ b/go-packages/meep-logger/logger.go
@@ -30,7 +30,7 @@ type Fields map[string]interface{}
 
 func MeepTextLogInit(name string) {
 	Formatter := new(logrus.TextFormatter)
-	Formatter.TimestampFormat = "2006-01-02T15:04:05.999999999Z07:00"
+	Formatter.TimestampFormat = "2006-01-02T15:04:05.999Z07:00"
 	Formatter.FullTimestamp = true
 	logrus.SetFormatter(Formatter)
 	//logrus.SetLevel(logrus.TraceLevel)

--- a/go-packages/meep-logger/logger.go
+++ b/go-packages/meep-logger/logger.go
@@ -30,14 +30,15 @@ var componentName string
 type Fields map[string]interface{}
 
 func MeepTextLogInit(name string) {
-	logrus.SetLevel(logrus.DebugLevel)
-	//SetSetReportCaller(true)
+	//logrus.SetLevel(logrus.TraceLevel)
+        logrus.SetLevel(logrus.DebugLevel)
 	componentName = name
 }
 
 func MeepJSONLogInit(name string) {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetLevel(logrus.DebugLevel)
+	//logrus.SetLevel(logrus.TraceLevel)
+        logrus.SetLevel(logrus.DebugLevel)
 	componentName = name
 }
 
@@ -80,6 +81,7 @@ func Warn(args ...interface{}) {
 		"meep.time": time.Now().String(),
 	}).Warn(args...)
 }
+
 func Error(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
@@ -87,6 +89,7 @@ func Error(args ...interface{}) {
 		"meep.time": time.Now().String(),
 	}).Error(args...)
 }
+
 func Panic(args ...interface{}) {
 	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,

--- a/go-packages/meep-logger/logger.go
+++ b/go-packages/meep-logger/logger.go
@@ -17,7 +17,12 @@
 package logger
 
 import (
-	log "github.com/sirupsen/logrus"
+	"net/http"
+	"time"
+	"runtime"
+	"path"
+	"fmt"
+	logrus "github.com/sirupsen/logrus"
 )
 
 var componentName string
@@ -25,51 +30,101 @@ var componentName string
 type Fields map[string]interface{}
 
 func MeepTextLogInit(name string) {
-	log.SetFormatter(&log.TextFormatter{})
-	log.SetLevel(log.DebugLevel)
+	logrus.SetLevel(logrus.DebugLevel)
+	//SetSetReportCaller(true)
 	componentName = name
 }
 
 func MeepJSONLogInit(name string) {
-	log.SetFormatter(&log.JSONFormatter{})
-	log.SetLevel(log.DebugLevel)
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetLevel(logrus.DebugLevel)
 	componentName = name
 }
 
+// getLogCaller
+// setReportCaller cannot ignore caller levels, so cannot work in a wrapper. Fix not merged in github, so doing it manually
+func getLogCaller() string {
+	_, file, line, _ := runtime.Caller(2)
+
+        location := fmt.Sprintf("%v:%v", path.Base(file), line)
+	return location
+}
+
 func Info(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.time": time.Now().String(),
 	}).Info(args...)
 }
 
 func Debug(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.from": getLogCaller(),
+		"meep.time": time.Now().String(),
 	}).Debug(args...)
 }
 
+func Trace(args ...interface{}) {
+        logrus.WithFields(logrus.Fields{
+                "meep.component": componentName,
+                "meep.from": getLogCaller(),
+                "meep.time": time.Now().String(),
+        }).Trace(args...)
+}
+
 func Warn(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.from": getLogCaller(),
+		"meep.time": time.Now().String(),
 	}).Warn(args...)
 }
 func Error(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.from": getLogCaller(),
+		"meep.time": time.Now().String(),
 	}).Error(args...)
 }
 func Panic(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.from": getLogCaller(),
+		"meep.time": time.Now().String(),
 	}).Panic(args...)
 }
 
 func Fatal(args ...interface{}) {
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"meep.component": componentName,
+		"meep.from": getLogCaller(),
+		"meep.time": time.Now().String(),
 	}).Fatal(args...)
 }
 
-func WithFields(fields Fields) *log.Entry {
-	return log.WithFields(log.Fields(fields))
+func WithFields(fields Fields) *logrus.Entry {
+	return logrus.WithFields(logrus.Fields(fields))
+}
+
+func httpLog(args ...interface{}) {
+        logrus.WithFields(logrus.Fields{
+                "meep.component": componentName,
+                "meep.from": getLogCaller(),
+                "meep.time": time.Now().String(),
+        }).Debug(args...)
+}
+
+func HTTP(inner http.Handler, name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		inner.ServeHTTP(w, r)
+
+		httpLog(
+			r.Method,
+			" ", r.RequestURI,
+			" apiFct: ", name,
+			" execTime: ", time.Since(start))
+	})
 }

--- a/go-packages/meep-model/model.go
+++ b/go-packages/meep-model/model.go
@@ -192,6 +192,7 @@ func (m *Model) Activate() (err error) {
 		log.Error(err.Error())
 		return err
 	}
+	log.Debug("TX-MSG [", m.ActiveChannel, "] ", EventActivate)
 	err = m.rc.Publish(m.ActiveChannel, EventActivate)
 	if err != nil {
 		log.Error(err.Error())
@@ -209,7 +210,7 @@ func (m *Model) Deactivate() (err error) {
 			log.Error("Failed to delete entry: ", err.Error())
 			return err
 		}
-
+	        log.Debug("TX-MSG [", m.ActiveChannel, "] ", EventTerminate)
 		err = m.rc.Publish(m.ActiveChannel, EventTerminate)
 		if err != nil {
 			log.Error("Failed to publish: ", err.Error())
@@ -522,6 +523,7 @@ func (m *Model) refresh() (err error) {
 			log.Error(err.Error())
 			return err
 		}
+	        log.Debug("TX-MSG [", m.ActiveChannel, "] ", EventUpdate)
 		err = m.rc.Publish(m.ActiveChannel, EventUpdate)
 		if err != nil {
 			log.Error(err.Error())

--- a/go-packages/meep-net-char-mgr/net-char-mgr.go
+++ b/go-packages/meep-net-char-mgr/net-char-mgr.go
@@ -197,10 +197,10 @@ func (ncm *NetCharManager) eventHandler(channel string, payload string) {
 	// Handle Message according to Rx Channel
 	switch channel {
 	case NetCharControlChannel:
-		log.Debug("Event received on channel: ", NetCharControlChannel)
+		log.Debug("Event received on channel: ", channel, " payload: ", payload)
 		ncm.updateControls()
 	case mod.ActiveScenarioEvents:
-		log.Debug("Event received on channel: ", mod.ActiveScenarioEvents)
+		log.Debug("Event received on channel: ", channel, " payload: ", payload)
 		ncm.processActiveScenarioUpdate()
 	default:
 		log.Warn("Unsupported channel")

--- a/go-packages/meep-redis/db.go
+++ b/go-packages/meep-redis/db.go
@@ -337,7 +337,7 @@ func (rc *Connector) Listen(handler func(string, string)) error {
 			case *redis.Message:
 				channel = m.Channel
 				payload = m.Payload
-				log.Info("RX-MSG [", channel, "] ", payload)
+				log.Trace("RX-MSG [", channel, "] ", payload)
 				handler(channel, payload)
 			}
 		}
@@ -366,7 +366,7 @@ func (rc *Connector) Publish(channel string, message string) error {
 		return errors.New("Redis Connector is disconnected (Publish)")
 	}
 
-	log.Info("TX-MSG [", channel, "] ", message)
+	log.Trace("TX-MSG [", channel, "] ", message)
 	_, err := rc.client.Publish(channel, message).Result()
 	return err
 }

--- a/go-packages/meep-redis/db.go
+++ b/go-packages/meep-redis/db.go
@@ -250,7 +250,7 @@ func (rc *Connector) JSONGetList(elem1 string, elem2 string, elementPath string,
 	keyName := elementPath + "*"
 	err := rc.ForEachJSONEntry(keyName, elem1, elem2, entryHandler, dataList)
 	if err != nil {
-		log.Error(err.Error())
+		log.Error("keyName: ", keyName, ": ", err.Error())
 		return err
 	}
 	return nil
@@ -264,7 +264,7 @@ func (rc *Connector) JSONSetEntry(key string, path string, json string) error {
 	// Update existing entry or create new entry if it does not exist
 	_, err := rc.client.JsonSet(key, path, json).Result()
 	if err != nil {
-		log.Error(err.Error())
+		log.Error("key: ", key, ": ", err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
Few log optimizations
1) logs are by default set in text mode, not in JSON anymore
2) logs extended to show the time of the system in us, file and line where the debug log was invoked from
3) every HTTP request is now logged at debug level
4) every event send or received from a channel is logged at Trace level from the redis package
5) every events send or received from a channel that was considered useful is logged at debug level prior to calling redis publish()
6) sidecar logs used for latencies removed (covered by influxDB)
7) call to redis to set an entry removed from a loop (ProcessRxTx) to outside the look for one write per cycle, rather than N write (N being the number of pods-1)
8) new Trace mode for extended debug
9) debugs added to show how much TC was busy on sidecars with performance metrics (duration of execution)
