### PR TITLE
grafana dashboards for meep http log

### DIFF
--- a/charts/grafana/dashboards/http-log-byId.json
+++ b/charts/grafana/dashboards/http-log-byId.json
@@ -91,7 +91,7 @@
           "unit": "short",
           "valueMaps": []
         },
-       {
+        {
           "alias": "Method",
           "colorMode": null,
           "colors": [
@@ -232,7 +232,7 @@
           "query": "SELECT body FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND (\"id\"=$http_log_id)",
           "rawQuery": true,
           "refId": "A",
-          "resultFormat": "table",
+          "resultFormat": "table"
         }
       ],
       "thresholds": "",
@@ -297,7 +297,7 @@
           "query": "SELECT resp_body FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND (\"id\"=$http_log_id)",
           "rawQuery": true,
           "refId": "A",
-          "resultFormat": "table",
+          "resultFormat": "table"
         }
       ],
       "thresholds": "",

--- a/charts/grafana/dashboards/http-log-byId.json
+++ b/charts/grafana/dashboards/http-log-byId.json
@@ -1,0 +1,414 @@
+{
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1588086315506,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 5,
+      "links": [],
+      "options": {},
+      "pageSize": null,
+      "pluginVersion": "6.4.2",
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "Type",
+          "colorMode": null,
+          "colors": [
+            "#C4162A",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.direction",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "Request",
+              "value": "RX"
+            },
+            {
+              "text": "Notification",
+              "value": "TX"
+            }
+          ]
+        },
+        {
+          "alias": "Id",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Service",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.logger_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+       {
+          "alias": "Method",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.method",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Endpoint with query parameterers",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.url",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Response code",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.resp_code",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Processing Time (us)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.proc_time",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [],
+          "hide": false,
+          "measurement": "http",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT id,direction,logger_name,url,method,resp_code,proc_time FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND (\"id\"=$http_log_id)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "transform": "timeseries_to_columns",
+      "type": "table"
+    },
+    {
+      "content": "",
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 30,
+      "mode": "markdown",
+      "options": {},
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Request Body",
+      "type": "text"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "$datasource",
+      "description": "",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 31,
+      "links": [],
+      "options": {
+        "showTime": false,
+        "sortOrder": "Descending"
+      },
+      "pluginVersion": "6.5.2",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "http",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT body FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND (\"id\"=$http_log_id)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "logs"
+    },
+    {
+      "content": "",
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 32,
+      "mode": "markdown",
+      "options": {},
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Response Body",
+      "type": "text"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "$datasource",
+      "description": "",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 33,
+      "links": [],
+      "options": {
+        "showTime": false,
+        "sortOrder": "Descending"
+      },
+      "pluginVersion": "6.5.2",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "http",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT resp_body FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND (\"id\"=$http_log_id)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "table",
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "logs"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 21,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "meep-influxdb",
+          "value": "meep-influxdb"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "demo1",
+          "value": "demo1"
+        },
+        "datasource": "$datasource",
+        "definition": "show databases",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "database",
+        "options": [],
+        "query": "show databases",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "ALL",
+        "current": {
+          "text": "ALL",
+          "value": "*"
+        },
+        "datasource": "$datasource",
+        "definition": "show tag values on $database from http with key = \"logger_name\"",
+        "hide": 0,
+        "includeAll": false,
+        "label": "service",
+        "multi": false,
+        "name": "logger_name",
+        "options": [],
+        "query": "show tag values on $database from http with key = \"logger_name\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "ALL",
+        "current": {
+          "text": "ALL",
+          "value": "*"
+        },
+        "datasource": "$datasource",
+        "definition": "show http log id selected",
+        "hide": 0,
+        "includeAll": false,
+        "label": "http log Id",
+        "multi": false,
+        "name": "http_log_id",
+        "options": [],
+        "query": "SELECT id FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) ORDER BY time desc LIMIT 100",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "timezone": "",
+  "title": "Http REST API single log details",
+  "uid": "4",
+  "version": 1
+}

--- a/charts/grafana/dashboards/http-loggers.json
+++ b/charts/grafana/dashboards/http-loggers.json
@@ -1,0 +1,267 @@
+{
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1588000376431,
+  "links": [],
+  "panels": [
+    {
+      "cacheTimeout": null,
+      "columns": [],
+      "datasource": "$datasource",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 4,
+      "links": [],
+      "options": {},
+      "pageSize": null,
+      "pluginVersion": "6.4.2",
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "Type",
+          "colorMode": null,
+          "colors": [
+            "#C4162A",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.direction",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": [
+            {
+              "text": "Request",
+              "value": "RX"
+            },
+            {
+              "text": "Notification",
+              "value": "TX"
+            }
+          ]
+        },
+        {
+          "alias": "Id",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank":true, 
+          "linkTooltip": "get details",
+          "linkUrl":"grafana/d/4/http-rest-api-single-log-details?orgId=1&var-database=$database&var-logger_name=$logger_name&theme=light&refresh=1d&var-http_log_id=${__cell}",
+          "mappingType": 1,
+          "pattern": "http.id",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Service",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.logger_name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Endpoint",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.endpoint",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Response code",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.resp_code",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "Processing Time (us)",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "http.proc_time",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [],
+          "hide": false,
+          "measurement": "http",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT id,direction,logger_name,endpoint,resp_code,proc_time FROM $database.autogen.http WHERE (\"logger_name\" =~ /^$logger_name$/) AND $timeFilter ORDER BY time desc LIMIT 100",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Http logs",
+      "transform": "timeseries_to_columns",
+      "type": "table"
+    }
+  ],
+  "refresh": "1s",
+  "schemaVersion": 21,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "meep-influxdb",
+          "value": "meep-influxdb"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "demo1",
+          "value": "demo1"
+        },
+        "datasource": "$datasource",
+        "definition": "show databases",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "database",
+        "options": [],
+        "query": "show databases",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": "ALL",
+        "current": {
+          "text": "ALL",
+          "value": "*"
+        },
+        "datasource": "$datasource",
+        "definition": "show tag values on $database from http with key = \"logger_name\"",
+        "hide": 0,
+        "includeAll": false,
+        "label": "service",
+        "multi": false,
+        "name": "logger_name",
+        "options": [],
+        "query": "show tag values on $database from http with key = \"logger_name\"",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1m",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Http REST API logs aggregation",
+  "uid": "3",
+  "version": 1
+}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -378,6 +378,12 @@ dashboards:
       file: dashboards/network-metrics-point-to-point.json
     network-metrics-aggregation:
       file: dashboards/network-metrics-aggregation.json
+    http-single-log:
+      file: dashboards/http-log-byId.json
+    http-logs-aggregation:
+      file: dashboards/http-loggers.json
+
+
   #   some-dashboard:
   #     json: |
   #       $RAW_JSON

--- a/js-apps/meep-frontend/src/js/meep-constants.js
+++ b/js-apps/meep-frontend/src/js/meep-constants.js
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-export const HOST_PATH = location.origin;
-// export const HOST_PATH = 'http://10.3.16.105';
-export const SANDBOX_NAME = 'sbox-1';
-
 // MEEP types
 export const TYPE_CFG = 'CFG';
 export const TYPE_EXEC = 'EXEC';
@@ -108,10 +104,6 @@ export const CFG_ELEM_PLACEMENT_ID = 'cfg-elem-placement-id';
 export const CFG_ELEM_CMD = 'cfg-elem-cmd';
 export const CFG_ELEM_ARGS = 'cfg-elem-args';
 export const CFG_ELEM_EXTERNAL_CHECK = 'cfg-elem-external-check';
-export const CFG_ELEM_MNC = 'cfg-elem-mnc';
-export const CFG_ELEM_MCC = 'cfg-elem-mcc';
-export const CFG_ELEM_DEFAULT_CELL_ID = 'cfg-elem-default-cell-id';
-export const CFG_ELEM_CELL_ID = 'cfg-elem-cell-id';
 export const CFG_ELEM_CHART_CHECK = 'cfg-elem-chart-check';
 export const CFG_ELEM_CHART_LOC = 'cfg-elem-chart-loc';
 export const CFG_ELEM_CHART_GROUP = 'cfg-elem-chart-group';
@@ -151,13 +143,10 @@ export const EXEC_EVT_REPLAY_FILES = 'exec-evt-replay-files';
 export const NO_SCENARIO_NAME = 'NO_SCENARIO_NAME_12Q(*&HGHG___--9098';
 
 export const DOMAIN_TYPE_STR = 'OPERATOR';
-export const DOMAIN_CELL_TYPE_STR = 'OPERATOR-CELL';
 export const PUBLIC_DOMAIN_TYPE_STR = 'PUBLIC';
 export const ZONE_TYPE_STR = 'ZONE';
 export const COMMON_ZONE_TYPE_STR = 'COMMON';
 export const NL_TYPE_STR = 'POA';
-export const POA_TYPE_STR = 'POA';
-export const POA_CELL_TYPE_STR = 'POA-CELL';
 export const DEFAULT_NL_TYPE_STR = 'DEFAULT';
 export const UE_TYPE_STR = 'UE';
 export const FOG_TYPE_STR = 'FOG';
@@ -171,12 +160,8 @@ export const CLOUD_APP_TYPE_STR = 'CLOUD-APP';
 
 export const ELEMENT_TYPE_SCENARIO = 'SCENARIO';
 export const ELEMENT_TYPE_OPERATOR = 'OPERATOR';
-export const ELEMENT_TYPE_OPERATOR_GENERIC = 'OPERATOR GENERIC';
-export const ELEMENT_TYPE_OPERATOR_CELL = 'OPERATOR CELLULAR';
 export const ELEMENT_TYPE_ZONE = 'ZONE';
 export const ELEMENT_TYPE_POA = 'POA';
-export const ELEMENT_TYPE_POA_GENERIC = 'POA GENERIC';
-export const ELEMENT_TYPE_POA_CELL = 'POA CELLULAR';
 export const ELEMENT_TYPE_DC = 'DISTANT CLOUD';
 export const ELEMENT_TYPE_CN = 'CORE NETWORK';
 export const ELEMENT_TYPE_EDGE = 'EDGE';
@@ -269,10 +254,18 @@ export const DEFAULT_DASHBOARD_OPTIONS = [
   },
   {
     label: 'Network Metrics Point-to-Point',
-    value: HOST_PATH + '/grafana/d/1/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: location.origin + '/grafana/d/1/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
   },
   {
     label: 'Network Metrics Aggregation',
-    value: HOST_PATH + '/grafana/d/2/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: location.origin + '/grafana/d/2/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+  },
+  {
+    label: 'Http REST API Logs Aggregation',
+    value: location.origin + '/grafana/d/3/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+  },
+  {
+    label: 'Http REST API Single Detailed Log',
+    value: location.origin + '/grafana/d/4/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1d&theme=light<exec><vars>'
   }
 ];

--- a/js-apps/meep-frontend/src/js/meep-constants.js
+++ b/js-apps/meep-frontend/src/js/meep-constants.js
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+export const HOST_PATH = location.origin;
+// export const HOST_PATH = 'http://10.3.16.105';
+export const SANDBOX_NAME = 'sbox-1';
+
 // MEEP types
 export const TYPE_CFG = 'CFG';
 export const TYPE_EXEC = 'EXEC';
@@ -104,6 +108,10 @@ export const CFG_ELEM_PLACEMENT_ID = 'cfg-elem-placement-id';
 export const CFG_ELEM_CMD = 'cfg-elem-cmd';
 export const CFG_ELEM_ARGS = 'cfg-elem-args';
 export const CFG_ELEM_EXTERNAL_CHECK = 'cfg-elem-external-check';
+export const CFG_ELEM_MNC = 'cfg-elem-mnc';
+export const CFG_ELEM_MCC = 'cfg-elem-mcc';
+export const CFG_ELEM_DEFAULT_CELL_ID = 'cfg-elem-default-cell-id';
+export const CFG_ELEM_CELL_ID = 'cfg-elem-cell-id';
 export const CFG_ELEM_CHART_CHECK = 'cfg-elem-chart-check';
 export const CFG_ELEM_CHART_LOC = 'cfg-elem-chart-loc';
 export const CFG_ELEM_CHART_GROUP = 'cfg-elem-chart-group';
@@ -143,10 +151,13 @@ export const EXEC_EVT_REPLAY_FILES = 'exec-evt-replay-files';
 export const NO_SCENARIO_NAME = 'NO_SCENARIO_NAME_12Q(*&HGHG___--9098';
 
 export const DOMAIN_TYPE_STR = 'OPERATOR';
+export const DOMAIN_CELL_TYPE_STR = 'OPERATOR-CELL';
 export const PUBLIC_DOMAIN_TYPE_STR = 'PUBLIC';
 export const ZONE_TYPE_STR = 'ZONE';
 export const COMMON_ZONE_TYPE_STR = 'COMMON';
 export const NL_TYPE_STR = 'POA';
+export const POA_TYPE_STR = 'POA';
+export const POA_CELL_TYPE_STR = 'POA-CELL';
 export const DEFAULT_NL_TYPE_STR = 'DEFAULT';
 export const UE_TYPE_STR = 'UE';
 export const FOG_TYPE_STR = 'FOG';
@@ -160,8 +171,12 @@ export const CLOUD_APP_TYPE_STR = 'CLOUD-APP';
 
 export const ELEMENT_TYPE_SCENARIO = 'SCENARIO';
 export const ELEMENT_TYPE_OPERATOR = 'OPERATOR';
+export const ELEMENT_TYPE_OPERATOR_GENERIC = 'OPERATOR GENERIC';
+export const ELEMENT_TYPE_OPERATOR_CELL = 'OPERATOR CELLULAR';
 export const ELEMENT_TYPE_ZONE = 'ZONE';
 export const ELEMENT_TYPE_POA = 'POA';
+export const ELEMENT_TYPE_POA_GENERIC = 'POA GENERIC';
+export const ELEMENT_TYPE_POA_CELL = 'POA CELLULAR';
 export const ELEMENT_TYPE_DC = 'DISTANT CLOUD';
 export const ELEMENT_TYPE_CN = 'CORE NETWORK';
 export const ELEMENT_TYPE_EDGE = 'EDGE';
@@ -254,18 +269,18 @@ export const DEFAULT_DASHBOARD_OPTIONS = [
   },
   {
     label: 'Network Metrics Point-to-Point',
-    value: location.origin + '/grafana/d/1/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/1/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
   },
   {
     label: 'Network Metrics Aggregation',
-    value: location.origin + '/grafana/d/2/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/2/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
   },
   {
     label: 'Http REST API Logs Aggregation',
-    value: location.origin + '/grafana/d/3/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/3/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
   },
   {
     label: 'Http REST API Single Detailed Log',
-    value: location.origin + '/grafana/d/4/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1d&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/4/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1d&theme=light<exec><vars>'
   }
 ];

--- a/test/cypress/integration/tests/scenario-monitor-spec.js
+++ b/test/cypress/integration/tests/scenario-monitor-spec.js
@@ -38,6 +38,10 @@ describe('Scenario Monitoring', function() {
     let noneStr = 'None';
     let networkMetricsPointToPointStr = 'Network Metrics Point-to-Point';
     let networkMetricsAggregationStr = 'Network Metrics Aggregation';
+    let httploggersAggregationStr = 'Http REST API Logs Aggregation';
+    let httpSingleLogStr = 'Http REST API Single Detailed Log';
+
+
 
     // Go to monitoring page
     cy.log('Go to monitoring page');
@@ -48,6 +52,9 @@ describe('Scenario Monitoring', function() {
     verify(meep.MON_DASHBOARD_SELECT, 'contain', noneStr);
     verify(meep.MON_DASHBOARD_SELECT, 'contain', networkMetricsPointToPointStr);
     verify(meep.MON_DASHBOARD_SELECT, 'contain', networkMetricsAggregationStr);
+    verify(meep.MON_DASHBOARD_SELECT, 'contain', httploggersAggregationStr);
+    verify(meep.MON_DASHBOARD_SELECT, 'contain', httpSingleLogStr);
+
 
     // Open Metrics Dashboard
     select(meep.MON_DASHBOARD_SELECT, networkMetricsPointToPointStr);


### PR DESCRIPTION
Grafana dashboard to display requests/notifications logged by package meep-http-logger to influxdb

One dashboard created to show all logs with basic information (time, id, type, service, endpoint,  response code, processing time)

One dashboard created to show detailed info for one log referenced using its unique id (time, id, type, service, endpoint with query parameters, method, response code, processing time, request body, response body)

cypress test ran