### PR TITLE
Http-logger not logging in influx

### DIFF
--- a/go-apps/meep-sandbox-ctrl/server/sandbox-ctrl.go
+++ b/go-apps/meep-sandbox-ctrl/server/sandbox-ctrl.go
@@ -168,6 +168,7 @@ func Run() (err error) {
 			log.Error("Failed to activate scenario with err: ", err.Error())
 		} else {
 			log.Info("Successfully activated scenario: ", scenarioName)
+			_ = httpLog.ReInit(moduleName, scenarioName)
 		}
 	}
 
@@ -289,8 +290,6 @@ func ceActivateScenario(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_ = httpLog.ReInit(moduleName, scenarioName)
-
 	// Activate scenario & publish
 	err = sbxCtrl.activeModel.SetScenario(scenario)
 	if err != nil {
@@ -304,6 +303,8 @@ func ceActivateScenario(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	_ = httpLog.ReInit(moduleName, scenarioName)
 
 	// Send Activation message to Virt Engine on Global Message Queue
 	msg := sbxCtrl.mqGlobal.CreateMsg(mq.MsgScenarioActivate, mq.TargetAll, mq.TargetAll)

--- a/go-packages/meep-http-logger/httpLogger.go
+++ b/go-packages/meep-http-logger/httpLogger.go
@@ -31,8 +31,8 @@ import (
 )
 
 var nextUniqueId int32 = 1
-var redisDBAddr string = "meep-redis-master:6379"
-var influxDBAddr string = "http://meep-influxdb:8086"
+var redisDBAddr string = "meep-redis-master.default.svc.cluster.local:6379"
+var influxDBAddr string = "http://meep-influxdb.default.svc.cluster.local:8086"
 var metricStore *ms.MetricStore
 var logComponent = ""
 

--- a/js-apps/meep-frontend/src/js/meep-constants.js
+++ b/js-apps/meep-frontend/src/js/meep-constants.js
@@ -277,10 +277,10 @@ export const DEFAULT_DASHBOARD_OPTIONS = [
   },
   {
     label: 'Http REST API Logs Aggregation',
-    value: HOST_PATH + '/grafana/d/3/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/3/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1s&theme=light'
   },
   {
     label: 'Http REST API Single Detailed Log',
-    value: HOST_PATH + '/grafana/d/4/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1d&theme=light<exec><vars>'
+    value: HOST_PATH + '/grafana/d/4/metrics-dashboard?orgId=1&var-datasource=meep-influxdb&refresh=1d&theme=light'
   }
 ];


### PR DESCRIPTION
http logger was not properly updated to use the sandbox namespace scheme. Now fixed.

Also removed the http loggers dashboard from execute Tab in frontend.