### PR TITLE
Sandbox Swagger UI

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 1.4.2
+version: 1.4.3
 repo:
   name: AdvantEDGE
 
@@ -31,6 +31,7 @@ repo:
           - -mod=vendor
         codecov: true
         lint: true
+        api: go-apps/meep-mon-engine/api/swagger.yaml
       meep-platform-ctrl:
         src: go-apps/meep-platform-ctrl
         bin: bin/meep-platform-ctrl
@@ -39,8 +40,8 @@ repo:
         lint: true
         api: go-apps/meep-platform-ctrl/api/swagger.yaml
         docker-data:
-          api: bin/meep-swagger-ui
-          static: bin/meep-frontend
+          swagger: bin/meep-platform-swagger-ui
+          frontend: bin/meep-frontend
       meep-virt-engine:
         src: go-apps/meep-virt-engine
         bin: bin/meep-virt-engine
@@ -75,12 +76,18 @@ repo:
           meep-platform-ctrl-api: js-packages/meep-platform-ctrl-client
           meep-sandbox-ctrl-api: js-packages/meep-sandbox-ctrl-client
           meep-mon-engine-api: js-packages/meep-mon-engine-client
-      meep-swagger-ui:
+      meep-platform-swagger-ui:
         src: js-apps/meep-swagger-ui
-        bin: bin/meep-swagger-ui
+        bin: bin/meep-platform-swagger-ui
         lint: false
         api-bundle:
           - core.go-apps.meep-platform-ctrl
+          - core.go-apps.meep-mon-engine
+      meep-sandbox-swagger-ui:
+        src: js-apps/meep-swagger-ui
+        bin: bin/meep-sandbox-swagger-ui
+        lint: false
+        api-bundle:
           - sandbox.go-apps.meep-sandbox-ctrl
           - sandbox.go-apps.meep-loc-serv
           - packages.go-packages.meep-loc-serv-notification-client
@@ -139,6 +146,9 @@ repo:
         codecov: false
         lint: true
         api: go-apps/meep-sandbox-ctrl/api/swagger.yaml
+        docker-data:
+          'entrypoint.sh': go-apps/meep-sandbox-ctrl/entrypoint.sh
+          swagger: bin/meep-sandbox-swagger-ui
       meep-tc-engine:
         src: go-apps/meep-tc-engine
         bin: bin/meep-tc-engine

--- a/charts/meep-loc-serv/templates/deployment.yaml
+++ b/charts/meep-loc-serv/templates/deployment.yaml
@@ -40,10 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
-            - name: MEEP_LOC_SERV_ROOT_URL
-              value: {{ .Values.image.env.rooturl }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -14,8 +14,8 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
-    rooturl: {{ .RootUrl }}
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
+    MEEP_HOST_URL: {{ .HostUrl }}
 
 service:
   name: meep-loc-serv
@@ -29,7 +29,7 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /({{ .SandboxName }}/|)location
+        - /{{ .SandboxName }}/location
 
   annotations:
     # kubernetes.io/ingress.class: nginx

--- a/charts/meep-metrics-engine/templates/deployment.yaml
+++ b/charts/meep-metrics-engine/templates/deployment.yaml
@@ -40,10 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
-            - name: MEEP_METRICS_ROOT_URL
-              value: {{ .Values.image.env.rooturl }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-metrics-engine/values-template.yaml
+++ b/charts/meep-metrics-engine/values-template.yaml
@@ -14,8 +14,8 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
-    rooturl: "http://www.example.com"
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
+    MEEP_HOST_URL: {{ .HostUrl }}
 
 service:
   name: meep-metrics-engine
@@ -29,7 +29,7 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /({{ .SandboxName }}/|)metrics
+        - /{{ .SandboxName }}/metrics
 
   annotations:
     # kubernetes.io/ingress.class: nginx

--- a/charts/meep-mg-manager/templates/deployment.yaml
+++ b/charts/meep-mg-manager/templates/deployment.yaml
@@ -40,8 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-mg-manager/values-template.yaml
+++ b/charts/meep-mg-manager/values-template.yaml
@@ -22,7 +22,7 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
     
 service:
   name: meep-mg-manager
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /({{ .SandboxName }}/|)mgm
+        - /{{ .SandboxName }}/mgm
 
   annotations:
     # kubernetes.io/ingress.class: nginx

--- a/charts/meep-rnis/templates/deployment.yaml
+++ b/charts/meep-rnis/templates/deployment.yaml
@@ -40,10 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
-            - name: MEEP_RNIS_ROOT_URL
-              value: {{ .Values.image.env.rooturl }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-rnis/values-template.yaml
+++ b/charts/meep-rnis/values-template.yaml
@@ -14,8 +14,8 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
-    rooturl: {{ .RootUrl }}
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
+    MEEP_HOST_URL: {{ .HostUrl }}
 
 service:
   name: meep-rnis
@@ -29,7 +29,7 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /({{ .SandboxName }}/|)rni
+        - /{{ .SandboxName }}/rni
 
   annotations:
     # kubernetes.io/ingress.class: nginx

--- a/charts/meep-sandbox-ctrl/templates/deployment.yaml
+++ b/charts/meep-sandbox-ctrl/templates/deployment.yaml
@@ -40,8 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-sandbox-ctrl/values-template.yaml
+++ b/charts/meep-sandbox-ctrl/values-template.yaml
@@ -22,7 +22,8 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
+    MEEP_HOST_URL: {{ .HostUrl }}
 
 service:
   type: ClusterIP
@@ -35,13 +36,16 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /({{ .SandboxName }}/|)sandbox-ctrl
+        - /{{ .SandboxName }}/api
+        - /{{ .SandboxName }}/sandbox-ctrl
 
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/{{ .SandboxName }}/api$ /{{ .SandboxName }}/api/ permanent;
+      rewrite ^/{{ .SandboxName }}/api(/|$)(.*)$ /api/$2 break;
       rewrite ^/{{ .SandboxName }}/sandbox-ctrl(/|$)(.*)$ /sandbox-ctrl/$2 break;
 
   labels: {}

--- a/charts/meep-tc-engine/templates/deployment.yaml
+++ b/charts/meep-tc-engine/templates/deployment.yaml
@@ -40,8 +40,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_SANDBOX_NAME
-              value: {{ .Values.image.env.sandboxName }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-tc-engine/values-template.yaml
+++ b/charts/meep-tc-engine/values-template.yaml
@@ -22,7 +22,7 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    sandboxName: {{ .SandboxName }}
+    MEEP_SANDBOX_NAME: {{ .SandboxName }}
     
 service:
   name: meep-tc-engine

--- a/charts/meep-virt-engine/templates/deployment.yaml
+++ b/charts/meep-virt-engine/templates/deployment.yaml
@@ -47,8 +47,10 @@ spec:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
           env:
-            - name: MEEP_ROOT_URL
-              value: {{ .Values.image.env.rooturl }}
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data/

--- a/charts/meep-virt-engine/values.yaml
+++ b/charts/meep-virt-engine/values.yaml
@@ -22,7 +22,7 @@ image:
   tag: latest
   pullPolicy: Always      
   env:
-    rooturl: "http://www.example.com"
+    MEEP_HOST_URL: "http://www.example.com"
 
 service:
   type: ClusterIP

--- a/go-apps/meep-platform-ctrl/Dockerfile
+++ b/go-apps/meep-platform-ctrl/Dockerfile
@@ -14,6 +14,6 @@
 
 FROM debian:9.6-slim
 COPY ./meep-platform-ctrl /meep-platform-ctrl
-COPY ./static /static
-COPY ./api /static/api
+COPY ./frontend /frontend
+COPY ./swagger /swagger
 ENTRYPOINT ["/meep-platform-ctrl"]

--- a/go-apps/meep-platform-ctrl/server/routers.go
+++ b/go-apps/meep-platform-ctrl/server/routers.go
@@ -56,8 +56,8 @@ func NewRouter() *mux.Router {
 	}
 
 	// Path prefix router order is important
-	router.PathPrefix("/api/").Handler(http.StripPrefix("/api/", http.FileServer(http.Dir("./static/api"))))
-	router.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("./static/"))))
+	router.PathPrefix("/api/").Handler(http.StripPrefix("/api/", http.FileServer(http.Dir("./swagger"))))
+	router.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("./frontend/"))))
 
 	return router
 }

--- a/go-apps/meep-sandbox-ctrl/Dockerfile
+++ b/go-apps/meep-sandbox-ctrl/Dockerfile
@@ -14,4 +14,9 @@
 
 FROM debian:9.6-slim
 COPY ./meep-sandbox-ctrl /meep-sandbox-ctrl
-ENTRYPOINT ["/meep-sandbox-ctrl"]
+COPY ./swagger /swagger
+COPY ./entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/go-apps/meep-sandbox-ctrl/entrypoint.sh
+++ b/go-apps/meep-sandbox-ctrl/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+echo "MEEP_SANDBOX_NAME: ${MEEP_SANDBOX_NAME}"
+echo "MEEP_HOST_URL: ${MEEP_HOST_URL}"
+
+# Prepend sandbox name to REST API yaml files
+for file in /swagger/*-api.yaml; do
+    echo "Prepending [${MEEP_SANDBOX_NAME}] to basepath in: $file"
+    sed -i 's,basePath: \"/\?,basePath: \"/'${MEEP_SANDBOX_NAME}'/,' $file;
+done
+
+# Update spec links in index.html
+# sed -i 's,"url": "\([^"]*\)","url": "'${MEEP_HOST_URL}'/'${MEEP_SANDBOX_NAME}'/api/\1",g' /swagger/index.html
+
+# Start virt engine
+exec /meep-sandbox-ctrl

--- a/go-apps/meep-sandbox-ctrl/server/routers.go
+++ b/go-apps/meep-sandbox-ctrl/server/routers.go
@@ -57,6 +57,9 @@ func NewRouter() *mux.Router {
 			Handler(handler)
 	}
 
+	// Path prefix router order is important
+	router.PathPrefix("/api/").Handler(http.StripPrefix("/api/", http.FileServer(http.Dir("./swagger"))))
+
 	return router
 }
 

--- a/go-apps/meep-virt-engine/server/chart-template.go
+++ b/go-apps/meep-virt-engine/server/chart-template.go
@@ -115,7 +115,7 @@ type ScenarioTemplate struct {
 type SandboxTemplate struct {
 	SandboxName string
 	Namespace   string
-	RootUrl     string
+	HostUrl     string
 }
 
 // Service map
@@ -500,7 +500,7 @@ func generateSandboxCharts(sandboxName string) (charts []helm.Chart, err error) 
 	var sandboxTemplate SandboxTemplate
 	sandboxTemplate.SandboxName = sandboxName
 	sandboxTemplate.Namespace = sandboxName
-	sandboxTemplate.RootUrl = ve.rootUrl + "/" + sandboxName
+	sandboxTemplate.HostUrl = ve.hostUrl
 
 	// Create sandbox charts
 	chartLocation, err := createChart("meep-loc-serv", sandboxName, "", sandboxTemplate)

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -45,7 +45,7 @@ type VirtEngine struct {
 	mqGlobal            *mq.MsgQueue
 	activeModels        map[string]*mod.Model
 	activeScenarioNames map[string]string
-	rootUrl             string
+	hostUrl             string
 	handlerId           int
 }
 
@@ -58,14 +58,14 @@ func Init() (err error) {
 	ve.activeModels = make(map[string]*mod.Model)
 	ve.activeScenarioNames = make(map[string]string)
 
-	// Retrieve Root URL from environment variable
-	ve.rootUrl = strings.TrimSpace(os.Getenv("MEEP_ROOT_URL"))
-	if ve.rootUrl == "" {
-		err = errors.New("MEEP_ROOT_URL env variable not set")
+	// Retrieve Host Name from environment variable
+	ve.hostUrl = strings.TrimSpace(os.Getenv("MEEP_HOST_URL"))
+	if ve.hostUrl == "" {
+		err = errors.New("MEEP_HOST_URL env variable not set")
 		log.Error(err.Error())
 		return err
 	}
-	log.Info("MEEP_ROOT_URL: ", ve.rootUrl)
+	log.Info("MEEP_HOST_URL: ", ve.hostUrl)
 
 	// Create message queue
 	ve.mqGlobal, err = mq.NewMsgQueue(mq.GetGlobalName(), moduleName, moduleNamespace, redisAddr)

--- a/go-apps/meepctl/cmd/build.go
+++ b/go-apps/meepctl/cmd/build.go
@@ -168,7 +168,9 @@ func buildJsApp(targetName string, repo string, cobraCmd *cobra.Command) {
 	switch targetName {
 	case "meep-frontend":
 		buildFrontend(targetName, repo, cobraCmd)
-	case "meep-swagger-ui":
+	case "meep-platform-swagger-ui":
+		buildSwaggerUi(targetName, repo, cobraCmd)
+	case "meep-sandbox-swagger-ui":
 		buildSwaggerUi(targetName, repo, cobraCmd)
 	default:
 		fmt.Println("Error: Unsupported JS App: ", targetName)

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -222,7 +222,7 @@ func deployRunScriptsAndGetFlags(targetName string, chart string, cobraCmd *cobr
 		}
 	case "meep-virt-engine":
 		flags = utils.HelmFlags(nil, "--set", "persistence.location="+deployData.workdir+"/virt-engine")
-		flags = utils.HelmFlags(flags, "--set", "image.env.rooturl=http://"+nodeIp)
+		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_HOST_URL=http://"+nodeIp)
 	case "meep-webhook":
 		cert, key, cabundle := deployCreateWebhookCerts(chart, cobraCmd)
 		flags = utils.HelmFlags(nil, "--set", "sidecar.image.repository="+deployData.registry+"/meep-tc-sidecar")

--- a/go-apps/meepctl/cmd/version.go
+++ b/go-apps/meepctl/cmd/version.go
@@ -41,7 +41,7 @@ type versionInfo struct {
 	BuildID   string `json:"build,omitempty"`
 }
 
-const meepctlVersion = "1.4.2"
+const meepctlVersion = "1.4.3"
 const na = "NA"
 
 const versionDesc = `Display version information

--- a/go-apps/meepctl/utils/config.go
+++ b/go-apps/meepctl/utils/config.go
@@ -31,7 +31,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const configVersion = "1.4.2"
+const configVersion = "1.4.3"
 
 const defaultNotSet = "not set"
 


### PR DESCRIPTION
**CHANGES:**
- Swagger UI:
  - Split _meep-swagger-ui_ into the following JS Apps:
    - meep-platform-swagger-ui
      - Platform Controller API
      - Mon Engine API
    - meep-sandbox-swagger-ui
      - Sandbox Controller API
      - Metrics Engine API
      - Location Service API
      - RNIS API
      - Mobility Group Service API
- Platform Controller:
  - Serves platform Swagger UI
    - Accessible via _http:\<host\>/api_
- Sandbox Controller:
  - Each instance serves swagger UI for its sandbox
    - Accessible via _http:\<host\>/\<sandbox name\>/api_
  - Added _entrypoint.sh_ script to run at microservice start
    - Script sets sandbox name in base path in swagger API files to enable 'Try-it-out' feature
- Virt Engine + Helm Charts:
  - Improved environment variable propagation @ helm chart install
  - Updated Ingress path rule & annotations to support sandbox swagger UI
  - Supported environemnt vars:
    - MEEP_SANDBOX_NAME: Propagated to all sandbox services by Virt Engine
    - MEEP_HOST_URL:  Provided to Virt Engine @ install time and propagated to sandbox services
- meepctl:
  - Added support for swagger UI split
  - Bumped version to 1.4.3

**TESTING:**
- UT & Cypress tests pass
- Manually tested platform & sandbox APIs using 'Try-it-out' feature in swagger UI
