### PR TITLE
Pod Status Monitoring

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 1.4.3
+version: 1.4.4
 repo:
   name: AdvantEDGE
 
@@ -31,6 +31,7 @@ repo:
           - -mod=vendor
         codecov: true
         lint: true
+        monitor: true
         api: go-apps/meep-mon-engine/api/swagger.yaml
       meep-platform-ctrl:
         src: go-apps/meep-platform-ctrl
@@ -38,6 +39,7 @@ repo:
         chart: charts/meep-platform-ctrl
         codecov: true
         lint: true
+        monitor: true
         api: go-apps/meep-platform-ctrl/api/swagger.yaml
         docker-data:
           swagger: bin/meep-platform-swagger-ui
@@ -48,6 +50,7 @@ repo:
         chart: charts/meep-virt-engine
         codecov: true
         lint: true
+        monitor: true
         docker-data:
           'entrypoint.sh': go-apps/meep-virt-engine/entrypoint.sh
           meep-loc-serv: charts/meep-loc-serv
@@ -65,6 +68,7 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
+        monitor: true
 
     # Javascript Applications
     js-apps:
@@ -113,6 +117,7 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
+        monitor: true
         api: go-apps/meep-loc-serv/api/swagger.yaml
       meep-metrics-engine:
         src: go-apps/meep-metrics-engine
@@ -122,6 +127,7 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
+        monitor: true
         api: go-apps/meep-metrics-engine/api/v2/swagger.yaml
       meep-mg-manager:
         src: go-apps/meep-mg-manager
@@ -129,6 +135,7 @@ repo:
         chart: charts/meep-mg-manager
         codecov: false
         lint: true
+        monitor: true
         api: go-apps/meep-mg-manager/api/swagger.yaml
       meep-rnis:
         src: go-apps/meep-rnis
@@ -138,6 +145,7 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
+        monitor: true
         api: go-apps/meep-rnis/api/swagger.yaml
       meep-sandbox-ctrl:
         src: go-apps/meep-sandbox-ctrl
@@ -145,6 +153,7 @@ repo:
         chart: charts/meep-sandbox-ctrl
         codecov: false
         lint: true
+        monitor: true
         api: go-apps/meep-sandbox-ctrl/api/swagger.yaml
         docker-data:
           'entrypoint.sh': go-apps/meep-sandbox-ctrl/entrypoint.sh
@@ -155,11 +164,13 @@ repo:
         chart: charts/meep-tc-engine
         codecov: false
         lint: true
+        monitor: true
       meep-tc-sidecar:
         src: go-apps/meep-tc-sidecar
         bin: bin/meep-tc-sidecar
         codecov: false
         lint: true
+        monitor: false
 
   #------------------------------
   #  Dependencies
@@ -167,22 +178,31 @@ repo:
   dep:
     meep-couchdb:
       chart: charts/couchdb
+      monitor: true
     meep-docker-registry:
       chart: charts/docker-registry
+      monitor: true
     meep-grafana:
       chart: charts/grafana
+      monitor: true
     meep-influxdb:
       chart: charts/influxdb
+      monitor: true
     meep-kube-state-metrics:
       chart: charts/kube-state-metrics
+      monitor: true
     meep-ingress:
       chart: charts/nginx-ingress
+      monitor: true
     meep-redis:
       chart: charts/redis
+      monitor: true
     meep-open-map-tiles:
       chart: charts/open-map-tiles
+      monitor: true
     meep-postgis:
       chart: charts/postgis
+      monitor: true
 
   #------------------------------
   #  Packages

--- a/charts/meep-mon-engine/templates/deployment.yaml
+++ b/charts/meep-mon-engine/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
           ports:
             - containerPort: {{ .Values.deployment.port }}
               protocol: {{ .Values.deployment.protocol }}
+          env:
+            {{- range $key, $value := .Values.image.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+            {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
           - name: codecov-storage

--- a/charts/meep-mon-engine/values.yaml
+++ b/charts/meep-mon-engine/values.yaml
@@ -21,6 +21,10 @@ image:
   repository: meep-mon-engine
   tag: latest
   pullPolicy: Always
+  env:
+    MEEP_DEPENDENCY_PODS: ""
+    MEEP_CORE_PODS: ""
+    MEEP_SANDBOX_PODS: "meep-loc-serv,meep-test"
 
 service:
   type: ClusterIP

--- a/charts/meep-mon-engine/values.yaml
+++ b/charts/meep-mon-engine/values.yaml
@@ -22,9 +22,10 @@ image:
   tag: latest
   pullPolicy: Always
   env:
+    # Provide comma-spearated list of expected pods to be monitored
     MEEP_DEPENDENCY_PODS: ""
     MEEP_CORE_PODS: ""
-    MEEP_SANDBOX_PODS: "meep-loc-serv,meep-test"
+    MEEP_SANDBOX_PODS: ""
 
 service:
   type: ClusterIP

--- a/go-apps/meep-mon-engine/go.mod
+++ b/go-apps/meep-mon-engine/go.mod
@@ -5,8 +5,9 @@ go 1.12
 require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger v0.0.0
-	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-model v0.0.0 // indirect
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis v0.0.0
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store v0.0.0
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -35,8 +36,8 @@ require (
 
 replace (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr => ../../go-packages/meep-data-key-mgr
-	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-model => ../../go-packages/meep-data-model
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger => ../../go-packages/meep-logger
-	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-model => ../../go-packages/meep-model
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq => ../../go-packages/meep-mq
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis => ../../go-packages/meep-redis
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store => ../../go-packages/meep-sandbox-store
 )

--- a/go-apps/meep-mon-engine/go.sum
+++ b/go-apps/meep-mon-engine/go.sum
@@ -2,10 +2,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/KromDaniel/jonson v0.0.0-20180630143114-d2f9c3c389db/go.mod h1:RU+6d0CNIRSp6yo1mXLIIrnFa/3LHhvcDVLVJyovptM=
 github.com/KromDaniel/rejonson v0.0.0-20180822072824-00b5bcf2b351 h1:1u1XrfCBnY+GijnyU6O1k4odp5TnqZQTsp5v7+n/E4Y=
 github.com/KromDaniel/rejonson v0.0.0-20180822072824-00b5bcf2b351/go.mod h1:HxwfbuElTuGf+/uKZfjJrCnv0BmmpkPJDI7gBwj1KkM=
-github.com/RyanCarrier/dijkstra v0.0.0-20190726134004-b51cadb5ae52/go.mod h1:DdR6ymcLl8+sN/XOVNjnYO1NDYfgHskGjreZUDuQCTY=
-github.com/RyanCarrier/dijkstra-1 v0.0.0-20170512020943-0e5801a26345/go.mod h1:OK4EvWJ441LQqGzed5NGB6vKBAE34n3z7iayPcEwr30=
-github.com/albertorestifo/dijkstra v0.0.0-20160910063646-aba76f725f72/go.mod h1:o+JdB7VetTHjLhU0N57x18B9voDBQe0paApdEAEoEfw=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -37,7 +33,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/mattomatic/dijkstra v0.0.0-20130617153013-6f6d134eb237/go.mod h1:UOnLAUmVG5paym8pD3C4B9BQylUDC2vXFJJpT7JrlEA=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
@@ -88,7 +83,6 @@ k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93 h1:tT6oQBi0qwLbbZSfDkdIsb
 k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=
 k8s.io/client-go v10.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
-k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/klog v0.0.0-20181108234604-8139d8cb77af h1:s6rm8OxBbyDNSRkpyAd5OL4icUdBICVw9+mFADa+t5E=
 k8s.io/klog v0.0.0-20181108234604-8139d8cb77af/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -97,11 +97,11 @@ var expectedSboxPods map[string]*PodStatus
 func Init() (err error) {
 
 	// Retrieve dependency pod list from environment variable
+	expectedDepPods = make(map[string]*PodStatus)
 	depPodsStr := strings.TrimSpace(os.Getenv("MEEP_DEPENDENCY_PODS"))
 	log.Info("MEEP_DEPENDENCY_PODS: ", depPodsStr)
 	if depPodsStr != "" {
 		depPodsList = strings.Split(depPodsStr, ",")
-		expectedDepPods = make(map[string]*PodStatus)
 		for _, pod := range depPodsList {
 			podStatus := new(PodStatus)
 			podStatus.PodType = "core"
@@ -113,11 +113,11 @@ func Init() (err error) {
 	}
 
 	// Retrieve core pod list from environment variable
+	expectedCorePods = make(map[string]*PodStatus)
 	corePodsStr := strings.TrimSpace(os.Getenv("MEEP_CORE_PODS"))
 	log.Info("MEEP_CORE_PODS: ", corePodsStr)
 	if corePodsStr != "" {
 		corePodsList = strings.Split(corePodsStr, ",")
-		expectedCorePods = make(map[string]*PodStatus)
 		for _, pod := range corePodsList {
 			podStatus := new(PodStatus)
 			podStatus.PodType = "core"
@@ -129,11 +129,11 @@ func Init() (err error) {
 	}
 
 	// Retrieve sandbox pod list from environment variable
+	expectedSboxPods = make(map[string]*PodStatus)
 	sboxPodsStr := strings.TrimSpace(os.Getenv("MEEP_SANDBOX_PODS"))
 	log.Info("MEEP_SANDBOX_PODS: ", sboxPodsStr)
 	if sboxPodsStr != "" {
 		sboxPodsList = strings.Split(sboxPodsStr, ",")
-		expectedSboxPods = make(map[string]*PodStatus)
 	}
 
 	// Create message queue

--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -20,12 +20,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	dkm "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr"
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+	mq "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq"
 	redis "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis"
+	ss "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -33,24 +36,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const notFoundStr string = "na"
-const monEngineKey string = "mon-engine:"
-
-var baseKey string = dkm.GetKeyRootGlobal() + monEngineKey
-
-//index in array
-const EVENT_POD_ADDED = 0
-const EVENT_POD_MODIFIED = 1
-const EVENT_POD_DELETED = 2
-
-var pod_event_str = [3]string{"pod added", "pod modified", "pod deleted"}
+type UserData struct {
+	AllPodsStatus PodsStatus
+	ExpectedPods  map[string]*PodStatus
+}
 
 type MonEngineInfo struct {
+	PodType              string
 	PodName              string
 	Namespace            string
 	MeepApp              string
 	MeepOrigin           string
 	MeepScenario         string
+	Release              string
 	Phase                string
 	PodInitialized       string
 	PodReady             string
@@ -65,15 +63,89 @@ type MonEngineInfo struct {
 	StartTime            string
 }
 
+const moduleName = "meep-mon-engine"
+const moduleNamespace = "default"
+const notFoundStr = "na"
+const monEngineKey = "mon-engine:"
+
+// MQ payload fields
+const fieldSandboxName = "sandbox-name"
+
+// index in array
+const EVENT_POD_ADDED = 0
+const EVENT_POD_MODIFIED = 1
+const EVENT_POD_DELETED = 2
+
+var pod_event_str = [3]string{"pod added", "pod modified", "pod deleted"}
 var rc *redis.Connector
-var redisDBAddr = "meep-redis-master:6379"
+var redisAddr = "meep-redis-master:6379"
+var baseKey string = dkm.GetKeyRootGlobal() + monEngineKey
 var stopChan = make(chan struct{})
+var mqGlobal *mq.MsgQueue
+var handlerId int
+var sandboxStore *ss.SandboxStore
+
+var depPodsList []string
+var corePodsList []string
+var sboxPodsList []string
+
+var expectedDepPods map[string]*PodStatus
+var expectedCorePods map[string]*PodStatus
+var expectedSboxPods map[string]*PodStatus
 
 // Init - Mon Engine initialization
 func Init() (err error) {
 
+	// Retrieve dependency pod list from environment variable
+	depPodsStr := strings.TrimSpace(os.Getenv("MEEP_DEPENDENCY_PODS"))
+	log.Info("MEEP_DEPENDENCY_PODS: ", depPodsStr)
+	if depPodsStr != "" {
+		depPodsList = strings.Split(depPodsStr, ",")
+		expectedDepPods = make(map[string]*PodStatus)
+		for _, pod := range depPodsList {
+			podStatus := new(PodStatus)
+			podStatus.PodType = "core"
+			podStatus.Sandbox = "default"
+			podStatus.Name = pod
+			podStatus.LogicalState = "NotAvailable"
+			expectedDepPods[pod] = podStatus
+		}
+	}
+
+	// Retrieve core pod list from environment variable
+	corePodsStr := strings.TrimSpace(os.Getenv("MEEP_CORE_PODS"))
+	log.Info("MEEP_CORE_PODS: ", corePodsStr)
+	if corePodsStr != "" {
+		corePodsList = strings.Split(corePodsStr, ",")
+		expectedCorePods = make(map[string]*PodStatus)
+		for _, pod := range corePodsList {
+			podStatus := new(PodStatus)
+			podStatus.PodType = "core"
+			podStatus.Sandbox = "default"
+			podStatus.Name = pod
+			podStatus.LogicalState = "NotAvailable"
+			expectedCorePods[pod] = podStatus
+		}
+	}
+
+	// Retrieve sandbox pod list from environment variable
+	sboxPodsStr := strings.TrimSpace(os.Getenv("MEEP_SANDBOX_PODS"))
+	log.Info("MEEP_SANDBOX_PODS: ", sboxPodsStr)
+	if sboxPodsStr != "" {
+		sboxPodsList = strings.Split(sboxPodsStr, ",")
+		expectedSboxPods = make(map[string]*PodStatus)
+	}
+
+	// Create message queue
+	mqGlobal, err = mq.NewMsgQueue(mq.GetGlobalName(), moduleName, moduleNamespace, redisAddr)
+	if err != nil {
+		log.Error("Failed to create Message Queue with error: ", err)
+		return err
+	}
+	log.Info("Message Queue created")
+
 	// Connect to Redis DB
-	rc, err = redis.NewConnector(redisDBAddr, 0)
+	rc, err = redis.NewConnector(redisAddr, 0)
 	if err != nil {
 		log.Error("Failed connection to Redis: ", err)
 		return err
@@ -83,11 +155,34 @@ func Init() (err error) {
 	// Empty DB
 	_ = rc.DBFlush(baseKey)
 
+	// Connect to Sandbox Store
+	sandboxStore, err = ss.NewSandboxStore(redisAddr)
+	if err != nil {
+		log.Error("Failed connection to Sandbox Store: ", err.Error())
+		return err
+	}
+	log.Info("Connected to Sandbox Store")
+
 	return nil
 }
 
 // Run - Mon Engine monitoring thread
 func Run() (err error) {
+
+	// Initialize expected pods for existing sandboxes
+	if sboxMap, err := sandboxStore.GetAll(); err == nil {
+		for _, sbox := range sboxMap {
+			addExpectedPods(sbox.Name)
+		}
+	}
+
+	// Register Message Queue handler
+	handler := mq.MsgHandler{Handler: msgHandler, UserData: nil}
+	handlerId, err = mqGlobal.RegisterHandler(handler)
+	if err != nil {
+		log.Error("Failed to register MsgQueue handler: ", err.Error())
+		return err
+	}
 
 	// Start thread to watch k8s pods
 	err = k8sConnect()
@@ -101,6 +196,20 @@ func Run() (err error) {
 
 func Stop() {
 	close(stopChan)
+}
+
+// Message Queue handler
+func msgHandler(msg *mq.Msg, userData interface{}) {
+	switch msg.Message {
+	case mq.MsgSandboxCreate:
+		log.Debug("RX MSG: ", mq.PrintMsg(msg))
+		addExpectedPods(msg.Payload[fieldSandboxName])
+	case mq.MsgSandboxDestroy:
+		log.Debug("RX MSG: ", mq.PrintMsg(msg))
+		removeExpectedPods(msg.Payload[fieldSandboxName])
+	default:
+		log.Trace("Ignoring unsupported message: ", mq.PrintMsg(msg))
+	}
 }
 
 func connectToAPISvr() (*kubernetes.Clientset, error) {
@@ -123,11 +232,13 @@ func connectToAPISvr() (*kubernetes.Clientset, error) {
 func printfMonEngineInfo(monEngineInfo MonEngineInfo, reason int) {
 
 	log.Debug("Monitoring Engine info *** ", pod_event_str[reason], " *** ",
-		" pod name : ", monEngineInfo.PodName,
+		" podType : ", monEngineInfo.PodType,
+		" podName : ", monEngineInfo.PodName,
 		" namespace : ", monEngineInfo.Namespace,
 		" meepApp : ", monEngineInfo.MeepApp,
 		" meepOrigin : ", monEngineInfo.MeepOrigin,
 		" meepScenario : ", monEngineInfo.MeepScenario,
+		" release : ", monEngineInfo.Release,
 		" phase : ", monEngineInfo.Phase,
 		" podInitialized : ", monEngineInfo.PodInitialized,
 		" podUnschedulable : ", monEngineInfo.PodUnschedulable,
@@ -143,124 +254,125 @@ func printfMonEngineInfo(monEngineInfo MonEngineInfo, reason int) {
 }
 
 func processEvent(obj interface{}, reason int) {
-	if pod, ok := obj.(*v1.Pod); ok {
+	var ok bool
+	var pod *v1.Pod
 
-		var monEngineInfo MonEngineInfo
+	// Validate object type is Pod
+	if pod, ok = obj.(*v1.Pod); !ok {
+		return
+	}
 
-		if reason != EVENT_POD_DELETED {
-			podConditionMsg := ""
-			podScheduled := "False"
-			podReady := "False"
-			podInitialized := "False"
-			podUnschedulable := "False"
-			nbConditions := len(pod.Status.Conditions)
-			for i := 0; i < nbConditions; i++ {
-				switch pod.Status.Conditions[i].Type {
-				case "PodScheduled":
-					podScheduled = string(pod.Status.Conditions[i].Status)
-				case "Ready":
-					podReady = string(pod.Status.Conditions[i].Status)
-					if podReady == "False" {
-						podConditionMsg = string(pod.Status.Conditions[i].Message)
-					}
-				case "Initialized":
-					podInitialized = string(pod.Status.Conditions[i].Status)
-				case "Unschedulable":
-					podUnschedulable = string(pod.Status.Conditions[i].Status)
+	var monEngineInfo MonEngineInfo
+
+	if reason != EVENT_POD_DELETED {
+		podConditionMsg := ""
+		podScheduled := "False"
+		podReady := "False"
+		podInitialized := "False"
+		podUnschedulable := "False"
+		nbConditions := len(pod.Status.Conditions)
+		for i := 0; i < nbConditions; i++ {
+			switch pod.Status.Conditions[i].Type {
+			case "PodScheduled":
+				podScheduled = string(pod.Status.Conditions[i].Status)
+			case "Ready":
+				podReady = string(pod.Status.Conditions[i].Status)
+				if podReady == "False" {
+					podConditionMsg = string(pod.Status.Conditions[i].Message)
 				}
-			}
-
-			nbContainers := len(pod.Status.ContainerStatuses)
-			okContainers := 0
-			restartCount := 0
-			reasonFailureStr := ""
-			for i := 0; i < nbContainers; i++ {
-				if pod.Status.ContainerStatuses[i].Ready {
-					okContainers++
-				} else {
-					if pod.Status.ContainerStatuses[i].State.Waiting != nil {
-						reasonFailureStr = pod.Status.ContainerStatuses[i].State.Waiting.Reason
-					} else if pod.Status.ContainerStatuses[i].State.Terminated != nil {
-						if reasonFailureStr != "" {
-							reasonFailureStr = pod.Status.ContainerStatuses[i].State.Terminated.Reason
-						}
-					}
-				}
-				//only update if the value is greater than 0, and we keep it
-				if restartCount == 0 {
-					restartCount = int(pod.Status.ContainerStatuses[i].RestartCount)
-				}
-			}
-
-			monEngineInfo.PodInitialized = podInitialized
-			monEngineInfo.PodUnschedulable = podUnschedulable
-			monEngineInfo.PodScheduled = podScheduled
-			monEngineInfo.PodReady = podReady
-			monEngineInfo.PodConditionError = podConditionMsg
-			monEngineInfo.ContainerStatusesMsg = reasonFailureStr
-			monEngineInfo.NbOkContainers = okContainers
-			monEngineInfo.NbTotalContainers = nbContainers
-			monEngineInfo.NbPodRestart = restartCount
-		}
-
-		//common for both the add, update and delete
-		monEngineInfo.Phase = string(pod.Status.Phase)
-		monEngineInfo.PodName = pod.Name
-		monEngineInfo.Namespace = pod.Namespace
-		monEngineInfo.MeepApp = pod.Labels["meepApp"]
-		monEngineInfo.MeepOrigin = pod.Labels["meepOrigin"]
-		monEngineInfo.MeepScenario = pod.Labels["meepScenario"]
-		if pod.Labels["meepApp"] != "" {
-			monEngineInfo.MeepApp = pod.Labels["meepApp"]
-		} else {
-			monEngineInfo.MeepApp = notFoundStr
-		}
-		if pod.Labels["meepOrigin"] != "" {
-			monEngineInfo.MeepOrigin = pod.Labels["meepOrigin"]
-		} else {
-			monEngineInfo.MeepOrigin = notFoundStr
-		}
-		if pod.Labels["meepScenario"] != "" {
-			monEngineInfo.MeepScenario = pod.Labels["meepScenario"]
-		} else {
-			monEngineInfo.MeepScenario = notFoundStr
-		}
-		monEngineInfo.LogicalState = monEngineInfo.Phase
-
-		//Phase is Running but might not really be because of some other attributes
-		//start of override section of the LogicalState by specific conditions
-
-		if pod.GetObjectMeta().GetDeletionTimestamp() != nil {
-			monEngineInfo.LogicalState = "Terminating"
-		} else {
-			if monEngineInfo.PodReady != "True" {
-				monEngineInfo.LogicalState = "Pending"
-			} else {
-				if monEngineInfo.NbOkContainers < monEngineInfo.NbTotalContainers {
-					monEngineInfo.LogicalState = "Failed"
-				}
+			case "Initialized":
+				podInitialized = string(pod.Status.Conditions[i].Status)
+			case "Unschedulable":
+				podUnschedulable = string(pod.Status.Conditions[i].Status)
 			}
 		}
-		//end of override section
 
-		printfMonEngineInfo(monEngineInfo, reason)
+		nbContainers := len(pod.Status.ContainerStatuses)
+		okContainers := 0
+		restartCount := 0
+		reasonFailureStr := ""
+		for i := 0; i < nbContainers; i++ {
+			if pod.Status.ContainerStatuses[i].Ready {
+				okContainers++
+			} else if pod.Status.ContainerStatuses[i].State.Waiting != nil {
+				reasonFailureStr = pod.Status.ContainerStatuses[i].State.Waiting.Reason
+			} else if pod.Status.ContainerStatuses[i].State.Terminated != nil && reasonFailureStr != "" {
+				reasonFailureStr = pod.Status.ContainerStatuses[i].State.Terminated.Reason
+			}
+			//only update if the value is greater than 0, and we keep it
+			if restartCount == 0 {
+				restartCount = int(pod.Status.ContainerStatuses[i].RestartCount)
+			}
+		}
 
+		monEngineInfo.PodInitialized = podInitialized
+		monEngineInfo.PodUnschedulable = podUnschedulable
+		monEngineInfo.PodScheduled = podScheduled
+		monEngineInfo.PodReady = podReady
+		monEngineInfo.PodConditionError = podConditionMsg
+		monEngineInfo.ContainerStatusesMsg = reasonFailureStr
+		monEngineInfo.NbOkContainers = okContainers
+		monEngineInfo.NbTotalContainers = nbContainers
+		monEngineInfo.NbPodRestart = restartCount
+	}
+
+	//common for both the add, update and delete
+	monEngineInfo.Phase = string(pod.Status.Phase)
+	monEngineInfo.PodName = pod.Name
+	monEngineInfo.Namespace = pod.Namespace
+	monEngineInfo.MeepApp = pod.Labels["meepApp"]
+	monEngineInfo.MeepScenario = pod.Labels["meepScenario"]
+	if monEngineInfo.Release, ok = pod.Labels["release"]; !ok {
+		monEngineInfo.Release = notFoundStr
+	}
+	if monEngineInfo.MeepApp, ok = pod.Labels["meepApp"]; !ok {
+		monEngineInfo.MeepApp = notFoundStr
+	}
+	if monEngineInfo.MeepOrigin, ok = pod.Labels["meepOrigin"]; !ok {
+		monEngineInfo.MeepOrigin = notFoundStr
+	}
+	if monEngineInfo.MeepScenario, ok = pod.Labels["meepScenario"]; !ok {
+		monEngineInfo.MeepScenario = notFoundStr
+	}
+	monEngineInfo.LogicalState = monEngineInfo.Phase
+	monEngineInfo.PodType = getPodType(monEngineInfo.MeepOrigin, monEngineInfo.Release)
+
+	//Phase is Running but might not really be because of some other attributes
+	//start of override section of the LogicalState by specific conditions
+
+	if pod.GetObjectMeta().GetDeletionTimestamp() != nil {
+		monEngineInfo.LogicalState = "Terminating"
+	} else if monEngineInfo.PodReady != "True" {
+		monEngineInfo.LogicalState = "Pending"
+	} else if monEngineInfo.NbOkContainers < monEngineInfo.NbTotalContainers {
+		monEngineInfo.LogicalState = "Failed"
+	}
+	//end of override section
+
+	printfMonEngineInfo(monEngineInfo, reason)
+
+	// Add, update or remove entry in DB only if core or scenario pod
+	if monEngineInfo.PodType != notFoundStr {
 		if reason == EVENT_POD_DELETED {
 			deleteEntryInDB(monEngineInfo)
 		} else {
 			addOrUpdateEntryInDB(monEngineInfo)
 		}
+	} else {
+		log.Debug("Ignoring non-AdvantEDGE pod: ", monEngineInfo.PodName)
 	}
 }
 
 func addOrUpdateEntryInDB(monEngineInfo MonEngineInfo) {
 	// Populate rule fields
 	fields := make(map[string]interface{})
+	fields["type"] = monEngineInfo.PodType
 	fields["name"] = monEngineInfo.PodName
 	fields["namespace"] = monEngineInfo.Namespace
 	fields["meepApp"] = monEngineInfo.MeepApp
 	fields["meepOrigin"] = monEngineInfo.MeepOrigin
 	fields["meepScenario"] = monEngineInfo.MeepScenario
+	fields["release"] = monEngineInfo.Release
 	fields["phase"] = monEngineInfo.Phase
 	fields["initialised"] = monEngineInfo.PodInitialized
 	fields["scheduled"] = monEngineInfo.PodScheduled
@@ -274,7 +386,7 @@ func addOrUpdateEntryInDB(monEngineInfo MonEngineInfo) {
 	fields["startTime"] = monEngineInfo.StartTime
 
 	// Make unique key
-	key := baseKey + monEngineInfo.MeepOrigin + ":" + monEngineInfo.Namespace + ":" + monEngineInfo.MeepScenario + ":" + monEngineInfo.MeepApp + ":" + monEngineInfo.PodName
+	key := baseKey + monEngineInfo.Namespace + ":" + monEngineInfo.PodType + ":" + monEngineInfo.PodName
 
 	// Set rule information in DB
 	err := rc.SetEntry(key, fields)
@@ -286,7 +398,7 @@ func addOrUpdateEntryInDB(monEngineInfo MonEngineInfo) {
 func deleteEntryInDB(monEngineInfo MonEngineInfo) {
 
 	// Make unique key
-	key := baseKey + monEngineInfo.MeepOrigin + ":" + monEngineInfo.Namespace + ":" + monEngineInfo.MeepScenario + ":" + monEngineInfo.MeepApp + ":" + monEngineInfo.PodName
+	key := baseKey + monEngineInfo.Namespace + ":" + monEngineInfo.PodType + ":" + monEngineInfo.PodName
 
 	// Set rule information in DB
 	err := rc.DelEntry(key)
@@ -302,23 +414,6 @@ func k8sConnect() (err error) {
 	if err != nil {
 		log.Error("Failed to connect with k8s API Server. Error: ", err)
 		return err
-	}
-
-	meepOrigin := "core"
-
-	// Retrieve pods from k8s api with scenario label
-	pods, err := clientset.CoreV1().Pods("").List(
-		metav1.ListOptions{LabelSelector: fmt.Sprintf("meepOrigin=%s", meepOrigin)})
-	if err != nil {
-		log.Error("Failed to retrieve services from k8s API Server. Error: ", err)
-		return err
-	}
-
-	// Log currently installed core pods
-	for _, pod := range pods.Items {
-		podName := pod.ObjectMeta.Name
-		podPhase := pod.Status.Phase
-		log.Debug("podName: ", podName, " podPhase: ", podPhase)
 	}
 
 	watchlist := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
@@ -348,8 +443,8 @@ func k8sConnect() (err error) {
 // Retrieve POD states
 // GET /states
 func meGetStates(w http.ResponseWriter, r *http.Request) {
-	var allPodsStatus PodsStatus
-	var filteredPodsStatus PodsStatus
+	var err error
+	var data UserData
 
 	// Retrieve query parameters
 	query := r.URL.Query()
@@ -357,13 +452,50 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 	querySandbox := query.Get("sandbox")
 	queryLong := query.Get("long")
 
-	// Retrieve pod status information
-	var err error
-	keyName := baseKey + "*"
-	if queryLong == "true" {
-		err = rc.ForEachEntry(keyName, getPodDetails, &allPodsStatus)
+	// Get expected pods list
+	data.ExpectedPods = make(map[string]*PodStatus)
+	if queryType != "scenario" {
+		if querySandbox == "" || querySandbox == "all" {
+			for k, v := range expectedCorePods {
+				data.ExpectedPods[k] = v
+			}
+			for k, v := range expectedDepPods {
+				data.ExpectedPods[k] = v
+			}
+		}
+		if querySandbox != "" || querySandbox == "all" {
+			for k, v := range expectedSboxPods {
+				if v.Sandbox == querySandbox || querySandbox == "all" {
+					data.ExpectedPods[k] = v
+				}
+			}
+		}
+	}
+
+	// Create DB key using query filters
+	sandboxKey := ""
+	if querySandbox == "" {
+		sandboxKey = "default:"
+	} else if querySandbox == "all" {
+		sandboxKey = "*:"
 	} else {
-		err = rc.ForEachEntry(keyName, getPodStatesOnly, &allPodsStatus)
+		sandboxKey = querySandbox + ":"
+	}
+
+	typeKey := ""
+	if queryType != "" {
+		typeKey = queryType + ":"
+	} else {
+		typeKey = "*"
+	}
+
+	keyName := baseKey + sandboxKey + typeKey + "*"
+
+	// Retrieve pod status information from DB
+	if queryLong == "true" {
+		err = rc.ForEachEntry(keyName, getPodDetails, &data)
+	} else {
+		err = rc.ForEachEntry(keyName, getPodStatesOnly, &data)
 	}
 	if err != nil {
 		log.Error(err.Error())
@@ -371,29 +503,15 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter results based on query parameters
-	for _, podStatus := range allPodsStatus.PodStatus {
-
-		// Filter on pod type
-		if (podStatus.PodType == notFoundStr) ||
-			(queryType == "core" && podStatus.PodType != "core") ||
-			(queryType == "scenario" && podStatus.PodType != "scenario") {
-			continue
-		}
-
-		// Filter on sandbox
-		if (querySandbox == "" && podStatus.Sandbox != "default") ||
-			(querySandbox != "" && querySandbox != "all" && querySandbox != podStatus.Sandbox) {
-			continue
-		}
-
-		filteredPodsStatus.PodStatus = append(filteredPodsStatus.PodStatus, podStatus)
+	// Add missing pods status
+	for _, podStatus := range data.ExpectedPods {
+		data.AllPodsStatus.PodStatus = append(data.AllPodsStatus.PodStatus, *podStatus)
 	}
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
 	// Format response
-	jsonResponse, err := json.Marshal(filteredPodsStatus)
+	jsonResponse, err := json.Marshal(data.AllPodsStatus)
 	if err != nil {
 		log.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -406,15 +524,13 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 }
 
 func getPodDetails(key string, fields map[string]string, userData interface{}) error {
-	podsStatus := userData.(*PodsStatus)
+	data := userData.(*UserData)
+
+	// Append pod status
 	var podStatus PodStatus
-	podStatus.PodType = fields["meepOrigin"]
+	podStatus.PodType = fields["type"]
 	podStatus.Sandbox = fields["namespace"]
-	if fields["meepApp"] != notFoundStr {
-		podStatus.Name = fields["meepApp"]
-	} else {
-		podStatus.Name = fields["name"]
-	}
+	podStatus.Name = getPodName(fields["meepApp"], fields["name"])
 	podStatus.Namespace = fields["namespace"]
 	podStatus.MeepApp = fields["meepApp"]
 	podStatus.MeepOrigin = fields["meepOrigin"]
@@ -430,22 +546,90 @@ func getPodDetails(key string, fields map[string]string, userData interface{}) e
 	podStatus.NbPodRestart = fields["nbPodRestart"]
 	podStatus.LogicalState = fields["logicalState"]
 	podStatus.StartTime = fields["startTime"]
+	data.AllPodsStatus.PodStatus = append(data.AllPodsStatus.PodStatus, podStatus)
 
-	podsStatus.PodStatus = append(podsStatus.PodStatus, podStatus)
+	// Remove from expected pods
+	delete(data.ExpectedPods, fields["release"])
+
 	return nil
 }
 
 func getPodStatesOnly(key string, fields map[string]string, userData interface{}) error {
-	podsStatus := userData.(*PodsStatus)
+	data := userData.(*UserData)
+
+	// Append pod status
 	var podStatus PodStatus
-	podStatus.PodType = fields["meepOrigin"]
+	podStatus.PodType = fields["type"]
 	podStatus.Sandbox = fields["namespace"]
-	if fields["meepApp"] != notFoundStr {
-		podStatus.Name = fields["meepApp"]
-	} else {
-		podStatus.Name = fields["name"]
-	}
+	podStatus.Name = getPodName(fields["meepApp"], fields["name"])
 	podStatus.LogicalState = fields["logicalState"]
-	podsStatus.PodStatus = append(podsStatus.PodStatus, podStatus)
+	data.AllPodsStatus.PodStatus = append(data.AllPodsStatus.PodStatus, podStatus)
+
+	// Remove from expected pods
+	delete(data.ExpectedPods, fields["release"])
+
 	return nil
+}
+
+func getPodType(origin string, release string) string {
+	podType := notFoundStr
+	if origin == "core" || origin == "scenario" {
+		podType = origin
+	} else if release != notFoundStr {
+		if _, ok := expectedDepPods[release]; ok {
+			podType = "core"
+		} else if _, ok := expectedCorePods[release]; ok {
+			podType = "core"
+		}
+	}
+	return podType
+}
+
+func getPodName(app string, name string) string {
+	var podName string
+	if app != notFoundStr {
+		podName = app
+	} else {
+		podName = name
+	}
+	return podName
+}
+
+func addExpectedPods(sandboxName string) {
+	for _, pod := range sboxPodsList {
+		// Get sandbox-specific pod name
+		var podName string
+		prefix := "meep-"
+		sandboxPrefix := prefix + sandboxName + "-"
+		if strings.HasPrefix(pod, prefix) {
+			podName = sandboxPrefix + pod[len(prefix):]
+		} else {
+			podName = sandboxPrefix + pod
+		}
+
+		// Add to expected sandbox pods list
+		podStatus := new(PodStatus)
+		podStatus.PodType = "core"
+		podStatus.Sandbox = sandboxName
+		podStatus.Name = podName
+		podStatus.LogicalState = "NotAvailable"
+		expectedSboxPods[podName] = podStatus
+	}
+}
+
+func removeExpectedPods(sandboxName string) {
+	for _, pod := range sboxPodsList {
+		// Get sandbox-specific pod name
+		var podName string
+		prefix := "meep-"
+		sandboxPrefix := prefix + sandboxName + "-"
+		if strings.HasPrefix(pod, prefix) {
+			podName = sandboxPrefix + pod[len(prefix):]
+		} else {
+			podName = sandboxPrefix + pod
+		}
+
+		// Delete from expected list
+		delete(expectedSboxPods, podName)
+	}
 }

--- a/go-apps/meep-platform-ctrl/server/platform-ctrl.go
+++ b/go-apps/meep-platform-ctrl/server/platform-ctrl.go
@@ -565,8 +565,8 @@ func createSandbox(sandboxName string, sandboxConfig *dataModel.SandboxConfig) (
 		return err
 	}
 
-	// Inform Virt Engine to create sandbox
-	msg := pfmCtrl.mqGlobal.CreateMsg(mq.MsgSandboxCreate, moduleVirtEngineName, moduleVirtEngineNamespace)
+	// Send message to create sandbox
+	msg := pfmCtrl.mqGlobal.CreateMsg(mq.MsgSandboxCreate, mq.TargetAll, mq.TargetAll)
 	msg.Payload[fieldSandboxName] = sandboxName
 	msg.Payload[fieldScenarioName] = sandboxConfig.ScenarioName
 	log.Debug("TX MSG: ", mq.PrintMsg(msg))
@@ -584,8 +584,8 @@ func deleteSandbox(sandboxName string) {
 	// Remove sandbox from store
 	pfmCtrl.sandboxStore.Del(sandboxName)
 
-	// Inform Virt Engine to destroy sandbox
-	msg := pfmCtrl.mqGlobal.CreateMsg(mq.MsgSandboxDestroy, moduleVirtEngineName, moduleVirtEngineNamespace)
+	// Send message to destroy sandbox
+	msg := pfmCtrl.mqGlobal.CreateMsg(mq.MsgSandboxDestroy, mq.TargetAll, mq.TargetAll)
 	msg.Payload[fieldSandboxName] = sandboxName
 	log.Debug("TX MSG: ", mq.PrintMsg(msg))
 	err := pfmCtrl.mqGlobal.SendMsg(msg)

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -328,11 +328,12 @@ func getPodList(target string) string {
 	podList := utils.GetTargets(target)
 	for _, pod := range podList {
 
-		// Exceptions
-		if pod == "meep-tc-sidecar" {
+		// Ignore targets with monitoring disabled
+		if !utils.RepoCfg.GetBool(target + "." + pod + ".monitor") {
 			continue
 		}
 
+		// Append target to pod list string
 		if podListStr != "" {
 			podListStr += "\\,"
 		}

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -224,6 +224,10 @@ func deployRunScriptsAndGetFlags(targetName string, chart string, cobraCmd *cobr
 			flags = utils.HelmFlags(flags, "--set", "controller.service.nodePorts.http="+httpPort)
 			flags = utils.HelmFlags(flags, "--set", "controller.service.nodePorts.https="+httpsPort)
 		}
+	case "meep-mon-engine":
+		flags = utils.HelmFlags(nil, "--set", "image.env.MEEP_DEPENDENCY_PODS="+getPodList("repo.dep"))
+		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_CORE_PODS="+getPodList("repo.core.go-apps"))
+		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_SANDBOX_PODS="+getPodList("repo.sandbox.go-apps"))
 	case "meep-virt-engine":
 		flags = utils.HelmFlags(nil, "--set", "persistence.location="+deployData.workdir+"/virt-engine")
 		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_HOST_URL=http://"+nodeIp)
@@ -317,4 +321,22 @@ func deployGetPorts() (string, string) {
 	ports := viper.GetString("meep.ports")
 	p := strings.Split(ports, "/")
 	return p[0], p[1]
+}
+
+func getPodList(target string) string {
+	podListStr := ""
+	podList := utils.GetTargets(target)
+	for _, pod := range podList {
+
+		// Exceptions
+		if pod == "meep-tc-sidecar" {
+			continue
+		}
+
+		if podListStr != "" {
+			podListStr += "\\,"
+		}
+		podListStr += pod
+	}
+	return podListStr
 }

--- a/go-apps/meepctl/cmd/version.go
+++ b/go-apps/meepctl/cmd/version.go
@@ -41,7 +41,7 @@ type versionInfo struct {
 	BuildID   string `json:"build,omitempty"`
 }
 
-const meepctlVersion = "1.4.3"
+const meepctlVersion = "1.4.4"
 const na = "NA"
 
 const versionDesc = `Display version information

--- a/go-apps/meepctl/utils/config.go
+++ b/go-apps/meepctl/utils/config.go
@@ -31,7 +31,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const configVersion = "1.4.3"
+const configVersion = "1.4.4"
 
 const defaultNotSet = "not set"
 

--- a/js-apps/meep-frontend/src/js/containers/meep-container.js
+++ b/js-apps/meep-frontend/src/js/containers/meep-container.js
@@ -211,7 +211,7 @@ class MeepContainer extends Component {
   checkPlatformStatus() {
     // Core pods
     axios
-      .get(`${basepathMonEngine}/states?long=true&type=core`)
+      .get(`${basepathMonEngine}/states?long=true&type=core&sandbox=all`)
       .then(res => {
         this.props.changeCorePodsPhases(res.data.podStatus);
       })

--- a/test/start-ut-env.sh
+++ b/test/start-ut-env.sh
@@ -10,7 +10,7 @@ echo ">>> Installing redis DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-redis --set master.service.nodePort=30380 $BASEDIR/../charts/redis/
+helm install --name meep-ut-redis --set meepOrigin="ut" --set master.service.nodePort=30380 $BASEDIR/../charts/redis/
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
@@ -18,7 +18,7 @@ echo ">>> Installing couch DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-couchdb --set service.nodePort=30985 --set persistentVolume.enabled=false --set persistentVolumeClaim.enabled=false $BASEDIR/../charts/couchdb/
+helm install --name meep-ut-couchdb --set meepOrigin="ut" --set service.nodePort=30985 --set persistentVolume.enabled=false --set persistentVolumeClaim.enabled=false $BASEDIR/../charts/couchdb/
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
@@ -26,4 +26,4 @@ echo ">>> Installing influx DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-influxdb --set service.type=NodePort --set service.apiNodePort=30986 --set service.rpcNodePort=30988 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/influxdb/
+helm install --name meep-ut-influxdb --set meepOrigin="ut" --set service.type=NodePort --set service.apiNodePort=30986 --set service.rpcNodePort=30988 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/influxdb/


### PR DESCRIPTION
**CHANGES:**
- Monitoring Engine:
  - Dependency, Core & Sandbox pod list injection via environment variables
  - Report missing pods status as "NotAvailable"
  - Added MQ handler to process sandboxes creation/destruction
    - Required to create list of expected sandbox pods
- Frontend:
  - LED status now reports core platform pods status + chosen sandbox pods status
- meepctl:
  - Retrieve list of microservices to monitor from meepctl repo cfg file
    - _monitor_ flag set to true indicates microservice should be monitored
  - Provide dep, core & sbox pods list to Mon Engine at helm chart install
  - bumped version to 1.4.4
- Charts:
  - Improved environment variable templating

**TESTING:**
- Cypress & UT pass
- Manually verified LED indication & REST API responses after removing a core & sandbox pod