### PR TITLE
Virt Engine Helm Concurrency

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -31,15 +31,35 @@ repo:
           - -mod=vendor
         codecov: true
         lint: true
-        monitor: true
         api: go-apps/meep-mon-engine/api/swagger.yaml
+        dependency-pods:
+          - meep-couchdb
+          - meep-docker-registry
+          - meep-grafana
+          - meep-ingress
+          - meep-influxdb
+          - meep-kube-state-metrics
+          - meep-open-map-tiles
+          - meep-postgis
+          - meep-redis
+        core-pods:
+          - meep-mon-engine
+          - meep-platform-ctrl
+          - meep-virt-engine
+          - meep-webhook
+        sandbox-pods:
+          - meep-loc-serv
+          - meep-metrics-engine
+          - meep-mg-manager
+          - meep-rnis
+          - meep-sandbox-ctrl
+          - meep-tc-engine
       meep-platform-ctrl:
         src: go-apps/meep-platform-ctrl
         bin: bin/meep-platform-ctrl
         chart: charts/meep-platform-ctrl
         codecov: true
         lint: true
-        monitor: true
         api: go-apps/meep-platform-ctrl/api/swagger.yaml
         docker-data:
           swagger: bin/meep-platform-swagger-ui
@@ -50,7 +70,6 @@ repo:
         chart: charts/meep-virt-engine
         codecov: true
         lint: true
-        monitor: true
         docker-data:
           'entrypoint.sh': go-apps/meep-virt-engine/entrypoint.sh
           meep-loc-serv: charts/meep-loc-serv
@@ -60,6 +79,13 @@ repo:
           meep-sandbox-ctrl: charts/meep-sandbox-ctrl
           meep-tc-engine: charts/meep-tc-engine
           meep-virt-chart-templates: charts/meep-virt-chart-templates
+        sandbox-pods:
+          - meep-loc-serv
+          - meep-metrics-engine
+          - meep-mg-manager
+          - meep-rnis
+          - meep-sandbox-ctrl
+          - meep-tc-engine
       meep-webhook:
         src: go-apps/meep-webhook
         bin: bin/meep-webhook
@@ -68,7 +94,6 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
-        monitor: true
 
     # Javascript Applications
     js-apps:
@@ -117,7 +142,6 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
-        monitor: true
         api: go-apps/meep-loc-serv/api/swagger.yaml
       meep-metrics-engine:
         src: go-apps/meep-metrics-engine
@@ -127,7 +151,6 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
-        monitor: true
         api: go-apps/meep-metrics-engine/api/v2/swagger.yaml
       meep-mg-manager:
         src: go-apps/meep-mg-manager
@@ -135,7 +158,6 @@ repo:
         chart: charts/meep-mg-manager
         codecov: false
         lint: true
-        monitor: true
         api: go-apps/meep-mg-manager/api/swagger.yaml
       meep-rnis:
         src: go-apps/meep-rnis
@@ -145,7 +167,6 @@ repo:
           - -mod=vendor
         codecov: false
         lint: true
-        monitor: true
         api: go-apps/meep-rnis/api/swagger.yaml
       meep-sandbox-ctrl:
         src: go-apps/meep-sandbox-ctrl
@@ -153,7 +174,6 @@ repo:
         chart: charts/meep-sandbox-ctrl
         codecov: false
         lint: true
-        monitor: true
         api: go-apps/meep-sandbox-ctrl/api/swagger.yaml
         docker-data:
           'entrypoint.sh': go-apps/meep-sandbox-ctrl/entrypoint.sh
@@ -164,13 +184,11 @@ repo:
         chart: charts/meep-tc-engine
         codecov: false
         lint: true
-        monitor: true
       meep-tc-sidecar:
         src: go-apps/meep-tc-sidecar
         bin: bin/meep-tc-sidecar
         codecov: false
         lint: true
-        monitor: false
 
   #------------------------------
   #  Dependencies
@@ -178,31 +196,22 @@ repo:
   dep:
     meep-couchdb:
       chart: charts/couchdb
-      monitor: true
     meep-docker-registry:
       chart: charts/docker-registry
-      monitor: true
     meep-grafana:
       chart: charts/grafana
-      monitor: true
     meep-influxdb:
       chart: charts/influxdb
-      monitor: true
     meep-kube-state-metrics:
       chart: charts/kube-state-metrics
-      monitor: true
     meep-ingress:
       chart: charts/nginx-ingress
-      monitor: true
     meep-redis:
       chart: charts/redis
-      monitor: true
     meep-open-map-tiles:
       chart: charts/open-map-tiles
-      monitor: true
     meep-postgis:
       chart: charts/postgis
-      monitor: true
 
   #------------------------------
   #  Packages

--- a/charts/meep-mon-engine/values.yaml
+++ b/charts/meep-mon-engine/values.yaml
@@ -22,7 +22,7 @@ image:
   tag: latest
   pullPolicy: Always
   env:
-    # Provide comma-spearated list of expected pods to be monitored
+    # Provide comma-separated list of expected pods to be monitored
     MEEP_DEPENDENCY_PODS: ""
     MEEP_CORE_PODS: ""
     MEEP_SANDBOX_PODS: ""

--- a/charts/meep-virt-engine/values.yaml
+++ b/charts/meep-virt-engine/values.yaml
@@ -22,6 +22,8 @@ image:
   tag: latest
   pullPolicy: Always      
   env:
+    # Provide comma-separated list of pods to create in sandbox
+    MEEP_SANDBOX_PODS: ""
     MEEP_HOST_URL: "http://www.example.com"
 
 service:

--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 
 	dkm "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr"
@@ -507,6 +508,11 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 	for _, podStatus := range data.ExpectedPods {
 		data.AllPodsStatus.PodStatus = append(data.AllPodsStatus.PodStatus, *podStatus)
 	}
+
+	// Sort pod status slice by name
+	sort.Slice(data.AllPodsStatus.PodStatus, func(i, j int) bool {
+		return data.AllPodsStatus.PodStatus[i].Name < data.AllPodsStatus.PodStatus[j].Name
+	})
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 

--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
 	"strings"
 
 	dkm "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr"
@@ -508,11 +507,6 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 	for _, podStatus := range data.ExpectedPods {
 		data.AllPodsStatus.PodStatus = append(data.AllPodsStatus.PodStatus, *podStatus)
 	}
-
-	// Sort pod status slice by name
-	sort.Slice(data.AllPodsStatus.PodStatus, func(i, j int) bool {
-		return data.AllPodsStatus.PodStatus[i].Name < data.AllPodsStatus.PodStatus[j].Name
-	})
 
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 

--- a/go-apps/meep-virt-engine/helm/delete.go
+++ b/go-apps/meep-virt-engine/helm/delete.go
@@ -24,13 +24,14 @@ import (
 
 func deleteReleases(charts []Chart) error {
 	for _, c := range charts {
-		go deleteRelease(c)
+		deleteRelease(c)
 	}
 
 	return nil
 }
 
 func deleteRelease(chart Chart) {
+	log.Debug("Deleting release: " + chart.ReleaseName)
 	var cmd = exec.Command("helm", "delete", chart.ReleaseName, "--purge")
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/go-apps/meep-virt-engine/helm/helm.go
+++ b/go-apps/meep-virt-engine/helm/helm.go
@@ -16,20 +16,6 @@
 
 package helm
 
-import (
-	"fmt"
-
-	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
-)
-
-const (
-	StateIdle       = "IDLE"
-	StateInstalling = "INSTALLING"
-	StateDeleting   = "DELETING"
-)
-
-var state string = StateIdle
-
 func GetReleasesName() ([]Release, error) {
 	return getReleasesName()
 }
@@ -39,31 +25,9 @@ func GetReleases() ([]Release, error) {
 }
 
 func InstallCharts(charts []Chart) error {
-	if state == StateIdle {
-		state = StateInstalling
-		go func() {
-			log.Debug("Installing ", len(charts), " Charts...")
-			_ = installCharts(charts)
-			log.Debug("Charts installed (", len(charts), ")")
-			state = StateIdle
-		}()
-		return nil
-	}
-	err := fmt.Errorf("Service busy [%s]", state)
-	return err
+	return runTask(Install, charts)
 }
 
 func DeleteReleases(charts []Chart) error {
-	if state == StateIdle {
-		state = StateDeleting
-		go func() {
-			log.Debug("Deleting ", len(charts), " Releases...")
-			_ = deleteReleases(charts)
-			log.Debug("Releases deleted (", len(charts), ")")
-			state = StateIdle
-		}()
-		return nil
-	}
-	err := fmt.Errorf("Service busy [%s]", state)
-	return err
+	return runTask(Delete, charts)
 }

--- a/go-apps/meep-virt-engine/helm/install.go
+++ b/go-apps/meep-virt-engine/helm/install.go
@@ -29,12 +29,17 @@ func installCharts(charts []Chart) error {
 	if err != nil {
 		return err
 	}
-	err = install(charts)
-	if err != nil {
-		// Cleanup release
-		cleanReleases(charts)
+
+	for _, chart := range charts {
+		err := install(chart)
+		if err != nil {
+			log.Info("Cleaning installed releases")
+			cleanReleases(charts)
+			return err
+		}
 	}
-	return err
+
+	return nil
 }
 
 func ensureReleases(charts []Chart) error {
@@ -52,31 +57,30 @@ func ensureReleases(charts []Chart) error {
 	return nil
 }
 
-func install(charts []Chart) error {
-	for _, c := range charts {
-		var cmd *exec.Cmd
-		if strings.Trim(c.ValuesFile, " ") == "" {
-			cmd = exec.Command("helm", "install",
-				"--name", c.ReleaseName,
-				"--namespace", c.Namespace,
-				"--set", "nameOverride="+c.Name,
-				"--set", "fullnameOverride="+c.Name,
-				c.Location, "--replace")
-		} else {
-			cmd = exec.Command("helm", "install",
-				"--name", c.ReleaseName,
-				"--namespace", c.Namespace,
-				"--set", "nameOverride="+c.Name,
-				"--set", "fullnameOverride="+c.Name,
-				"-f", c.ValuesFile,
-				c.Location, "--replace")
-		}
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			log.Error("Failed to install Release [" + c.ReleaseName + "] at " + c.Location)
-			log.Error("Error(", err.Error(), "): ", string(out))
-			return err
-		}
+func install(chart Chart) error {
+	log.Debug("Installing chart: " + chart.ReleaseName)
+	var cmd *exec.Cmd
+	if strings.Trim(chart.ValuesFile, " ") == "" {
+		cmd = exec.Command("helm", "install",
+			"--name", chart.ReleaseName,
+			"--namespace", chart.Namespace,
+			"--set", "nameOverride="+chart.Name,
+			"--set", "fullnameOverride="+chart.Name,
+			chart.Location, "--replace")
+	} else {
+		cmd = exec.Command("helm", "install",
+			"--name", chart.ReleaseName,
+			"--namespace", chart.Namespace,
+			"--set", "nameOverride="+chart.Name,
+			"--set", "fullnameOverride="+chart.Name,
+			"-f", chart.ValuesFile,
+			chart.Location, "--replace")
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error("Failed to install Release [" + chart.ReleaseName + "] at " + chart.Location)
+		log.Error("Error(", err.Error(), "): ", string(out))
+		return err
 	}
 	return nil
 }
@@ -85,7 +89,6 @@ func cleanReleases(charts []Chart) {
 	var toClean []Chart
 	var cnt int
 	releases, _ := GetReleasesName()
-	// ensure that releases do not exist
 
 	for _, c := range charts {
 		for _, r := range releases {
@@ -97,6 +100,6 @@ func cleanReleases(charts []Chart) {
 	}
 
 	if cnt > 0 {
-		_ = DeleteReleases(toClean)
+		_ = deleteReleases(toClean)
 	}
 }

--- a/go-apps/meep-virt-engine/helm/worker.go
+++ b/go-apps/meep-virt-engine/helm/worker.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helm
+
+import (
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+type Task string
+
+const (
+	Install Task = "INSTALL"
+	Delete  Task = "DELETE"
+)
+
+type Job struct {
+	task   Task
+	charts []Chart
+}
+
+var queue *chan Job = nil
+
+func startWorker() {
+	if queue != nil {
+		return
+	}
+	queueChan := make(chan Job, 5)
+	queue = &queueChan
+
+	go func() {
+		for job := range queueChan {
+			switch job.task {
+			case Install:
+				log.Debug("Installing ", len(job.charts), " Charts...")
+				_ = installCharts(job.charts)
+				log.Debug("Charts installed (", len(job.charts), ")")
+
+			case Delete:
+				log.Debug("Deleting ", len(job.charts), " Releases...")
+				_ = deleteReleases(job.charts)
+				log.Debug("Releases deleted (", len(job.charts), ")")
+			}
+		}
+		queue = nil
+	}()
+}
+
+func runTask(task Task, charts []Chart) error {
+	startWorker()
+	var job Job = Job{task: task, charts: charts}
+	*queue <- job
+	return nil
+}

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -188,7 +188,7 @@ func terminateScenario(sandboxName string) {
 		for range ticker.C {
 			err, chartsToDelete := deleteReleases(sandboxName, scenarioName)
 			if err == nil && chartsToDelete == 0 {
-				// Remove modle & cached scenario
+				// Remove model & cached scenario
 				ve.activeScenarioNames[sandboxName] = ""
 				ticker.Stop()
 				return

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -47,6 +47,7 @@ type VirtEngine struct {
 	activeScenarioNames map[string]string
 	hostUrl             string
 	handlerId           int
+	sboxPods            map[string]string
 }
 
 var ve *VirtEngine
@@ -57,6 +58,22 @@ func Init() (err error) {
 	ve = new(VirtEngine)
 	ve.activeModels = make(map[string]*mod.Model)
 	ve.activeScenarioNames = make(map[string]string)
+
+	// Retrieve sandbox pods list from environment variable
+	ve.sboxPods = make(map[string]string)
+	sboxPodsStr := strings.TrimSpace(os.Getenv("MEEP_SANDBOX_PODS"))
+	log.Info("MEEP_SANDBOX_PODS: ", sboxPodsStr)
+	if sboxPodsStr != "" {
+		sboxPodsList := strings.Split(sboxPodsStr, ",")
+		for _, pod := range sboxPodsList {
+			ve.sboxPods[pod] = pod
+		}
+	}
+	if len(ve.sboxPods) == 0 {
+		err = errors.New("MEEP_SANDBOX_PODS env variable does not contain sbox pod list")
+		log.Error(err.Error())
+		return err
+	}
 
 	// Retrieve Host Name from environment variable
 	ve.hostUrl = strings.TrimSpace(os.Getenv("MEEP_HOST_URL"))

--- a/js-apps/meep-frontend/src/js/containers/exec/exec-page-container.js
+++ b/js-apps/meep-frontend/src/js/containers/exec/exec-page-container.js
@@ -498,7 +498,10 @@ class ExecPageContainer extends Component {
             </Grid>
           </>
         )}
-        <ExecTable />
+        
+        {sandbox && 
+          <ExecTable />
+        }
       </div>
     );
   }


### PR DESCRIPTION
**CHANGES:**
- Virt Engine:
  - Added worker goroutine to queue & process helm install/delete requests
  - Job channel supports up to 5 queued tasks before blocking
  - MEEP_SANDBOX_PODS environment variable now used to provision list of sandbox microservices to deploy at sandbox creation
- meepctl & Charts:
  - Configurable Sandbox pod list provisioning in Virt Engine
  - Configurable Dependency, Core & Sandbox pod list provisioning in Monitoring Engine

**TESTING:**
- Cypress tests pass