### PR TITLE
User specific configuration

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -46,6 +46,8 @@ repo:
         bin: bin/meep-mon-engine
         # location of deployment chart
         chart: charts/meep-mon-engine
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-mon-engine.yaml
         # extra build flags
         build-flags:
           - -mod=vendor
@@ -94,6 +96,8 @@ repo:
         bin: bin/meep-platform-ctrl
         # location of deployment chart
         chart: charts/meep-platform-ctrl
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-platform-ctrl.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -119,6 +123,8 @@ repo:
         bin: bin/meep-virt-engine
         # location of deployment chart
         chart: charts/meep-virt-engine
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-virt-engine.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -158,6 +164,8 @@ repo:
         bin: bin/meep-webhook
         # location of deployment chart
         chart: charts/meep-webhook
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-webhook.yaml
         # extra build flags
         build-flags:
           - -mod=vendor
@@ -252,6 +260,8 @@ repo:
         bin: bin/meep-gis-engine
         # location of deployment chart
         chart: charts/meep-gis-engine
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-gis-engine.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -271,6 +281,8 @@ repo:
         bin: bin/meep-loc-serv
         # location of deployment chart
         chart: charts/meep-loc-serv
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-loc-serv.yaml
         # extra build flags
         build-flags:
           - -mod=vendor
@@ -293,6 +305,8 @@ repo:
         bin: bin/meep-metrics-engine
         # location of deployment chart
         chart: charts/meep-metrics-engine
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-metrics-engine.yaml
         # extra build flags
         build-flags:
           - -mod=vendor
@@ -315,6 +329,8 @@ repo:
         bin: bin/meep-mg-manager
         # location of deployment chart
         chart: charts/meep-mg-manager
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-mg-manager.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -334,6 +350,8 @@ repo:
         bin: bin/meep-rnis
         # location of deployment chart
         chart: charts/meep-rnis
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-rnis.yaml
         # extra build flags
         build-flags:
           - -mod=vendor
@@ -356,6 +374,8 @@ repo:
         bin: bin/meep-sandbox-ctrl
         # location of deployment chart
         chart: charts/meep-sandbox-ctrl
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-sandbox-ctrl.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -378,6 +398,8 @@ repo:
         bin: bin/meep-tc-engine
         # location of deployment chart
         chart: charts/meep-tc-engine
+        # user supplied value file located @ .meep/user/values
+        chart-user-values: meep-tc-engine.yaml
         # enable meepctl build
         build: true
         # enable meepctl dockerize
@@ -417,6 +439,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/couchdb
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-couchdb.yaml
     meep-docker-registry:
       # enable meepctl build -> deps are never built
       build: false
@@ -426,6 +450,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/docker-registry
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-docker-registry.yaml
     meep-grafana:
       # enable meepctl build -> deps are never built
       build: false
@@ -435,6 +461,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/grafana
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-grafana.yaml
     meep-influxdb:
       # enable meepctl build -> deps are never built
       build: false
@@ -444,6 +472,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/influxdb
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-influxdb.yaml
     meep-kube-state-metrics:
       # enable meepctl build -> deps are never built
       build: false
@@ -453,6 +483,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/kube-state-metrics
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-kube-state-metrics.yaml
     meep-ingress:
       # enable meepctl build -> deps are never built
       build: false
@@ -462,6 +494,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/nginx-ingress
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-ingress.yaml
     meep-alt-ingress:
       # enable meepctl build -> deps are never built
       build: false
@@ -471,7 +505,10 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/nginx-ingress
+      # uses different default values
       values: charts/nginx-ingress/alt-values.yaml
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-alt-ingress.yaml
     meep-redis:
       # enable meepctl build -> deps are never built
       build: false
@@ -481,6 +518,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/redis
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-redis.yaml
     meep-open-map-tiles:
       # enable meepctl build -> deps are never built
       build: false
@@ -490,6 +529,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/open-map-tiles
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-open-map-tiles.yaml
     meep-postgis:
       # enable meepctl build -> deps are never built
       build: false
@@ -499,6 +540,8 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/postgis
+      # user supplied value file located @ .meep/user/values
+      chart-user-values: meep-postgis.yaml
 
   #------------------------------
   #  Packages

--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -46,7 +46,7 @@ repo:
         bin: bin/meep-mon-engine
         # location of deployment chart
         chart: charts/meep-mon-engine
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-mon-engine.yaml
         # extra build flags
         build-flags:
@@ -96,7 +96,7 @@ repo:
         bin: bin/meep-platform-ctrl
         # location of deployment chart
         chart: charts/meep-platform-ctrl
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-platform-ctrl.yaml
         # enable meepctl build
         build: true
@@ -123,7 +123,7 @@ repo:
         bin: bin/meep-virt-engine
         # location of deployment chart
         chart: charts/meep-virt-engine
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-virt-engine.yaml
         # enable meepctl build
         build: true
@@ -164,7 +164,7 @@ repo:
         bin: bin/meep-webhook
         # location of deployment chart
         chart: charts/meep-webhook
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-webhook.yaml
         # extra build flags
         build-flags:
@@ -260,7 +260,7 @@ repo:
         bin: bin/meep-gis-engine
         # location of deployment chart
         chart: charts/meep-gis-engine
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-gis-engine.yaml
         # enable meepctl build
         build: true
@@ -281,7 +281,7 @@ repo:
         bin: bin/meep-loc-serv
         # location of deployment chart
         chart: charts/meep-loc-serv
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-loc-serv.yaml
         # extra build flags
         build-flags:
@@ -305,7 +305,7 @@ repo:
         bin: bin/meep-metrics-engine
         # location of deployment chart
         chart: charts/meep-metrics-engine
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-metrics-engine.yaml
         # extra build flags
         build-flags:
@@ -329,7 +329,7 @@ repo:
         bin: bin/meep-mg-manager
         # location of deployment chart
         chart: charts/meep-mg-manager
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-mg-manager.yaml
         # enable meepctl build
         build: true
@@ -350,7 +350,7 @@ repo:
         bin: bin/meep-rnis
         # location of deployment chart
         chart: charts/meep-rnis
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-rnis.yaml
         # extra build flags
         build-flags:
@@ -374,7 +374,7 @@ repo:
         bin: bin/meep-sandbox-ctrl
         # location of deployment chart
         chart: charts/meep-sandbox-ctrl
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-sandbox-ctrl.yaml
         # enable meepctl build
         build: true
@@ -398,7 +398,7 @@ repo:
         bin: bin/meep-tc-engine
         # location of deployment chart
         chart: charts/meep-tc-engine
-        # user supplied value file located @ .meep/user/values
+        # user supplied value file located @ .meep/user/values (use below file name)
         chart-user-values: meep-tc-engine.yaml
         # enable meepctl build
         build: true
@@ -439,7 +439,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/couchdb
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-couchdb.yaml
     meep-docker-registry:
       # enable meepctl build -> deps are never built
@@ -450,7 +450,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/docker-registry
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-docker-registry.yaml
     meep-grafana:
       # enable meepctl build -> deps are never built
@@ -461,7 +461,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/grafana
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-grafana.yaml
     meep-influxdb:
       # enable meepctl build -> deps are never built
@@ -472,7 +472,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/influxdb
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-influxdb.yaml
     meep-kube-state-metrics:
       # enable meepctl build -> deps are never built
@@ -483,7 +483,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/kube-state-metrics
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-kube-state-metrics.yaml
     meep-ingress:
       # enable meepctl build -> deps are never built
@@ -494,7 +494,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/nginx-ingress
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-ingress.yaml
     meep-alt-ingress:
       # enable meepctl build -> deps are never built
@@ -507,7 +507,7 @@ repo:
       chart: charts/nginx-ingress
       # uses different default values
       values: charts/nginx-ingress/alt-values.yaml
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-alt-ingress.yaml
     meep-redis:
       # enable meepctl build -> deps are never built
@@ -518,7 +518,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/redis
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-redis.yaml
     meep-open-map-tiles:
       # enable meepctl build -> deps are never built
@@ -529,7 +529,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/open-map-tiles
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-open-map-tiles.yaml
     meep-postgis:
       # enable meepctl build -> deps are never built
@@ -540,7 +540,7 @@ repo:
       deploy: true
       # location of deployment chart
       chart: charts/postgis
-      # user supplied value file located @ .meep/user/values
+      # user supplied value file located @ .meep/user/values (use below file name)
       chart-user-values: meep-postgis.yaml
 
   #------------------------------

--- a/charts/couchdb/values.yaml
+++ b/charts/couchdb/values.yaml
@@ -81,9 +81,10 @@ podManagementPolicy: Parallel
 ## to a second Service that governs how clients connect to the CouchDB cluster.
 service:
   enabled: true
-  type: NodePort
+  type: ClusterIP
+  #type: NodePort
   externalPort: 5984
-  nodePort: 30984
+  #nodePort: 30984
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed

--- a/charts/meep-platform-ctrl/templates/service.yaml
+++ b/charts/meep-platform-ctrl/templates/service.yaml
@@ -17,6 +17,6 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.deployment.port }}
-      {{- if .Values.nodePort }}
+      {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/meep-virt-engine/templates/deployment.yaml
+++ b/charts/meep-virt-engine/templates/deployment.yaml
@@ -23,13 +23,16 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       volumes:
-        - name: data
         {{- if .Values.persistence.enabled }}
+        - name: data
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "meep-virt-engine.fullname" . }}{{- end }}
-        {{- else }}
-          emptyDir: {}
         {{- end -}}
+        {{- if .Values.user.values.enabled}}
+          - name: user-values-storage
+            persistentVolumeClaim:
+              claimName: meep-virt-engine-user-values-pvc
+        {{- end}}
         {{- if .Values.codecov.enabled}}
         - name: codecov-storage
           persistentVolumeClaim:
@@ -54,6 +57,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/
+            {{- if .Values.user.values.enabled}}
+              - name: user-values-storage
+                mountPath: {{ .Values.user.values.mountpath }}
+            {{- end}}
             {{- if .Values.codecov.enabled}}
             - name: codecov-storage
               mountPath: /codecov

--- a/charts/meep-virt-engine/templates/deployment.yaml
+++ b/charts/meep-virt-engine/templates/deployment.yaml
@@ -29,9 +29,9 @@ spec:
             claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "meep-virt-engine.fullname" . }}{{- end }}
         {{- end -}}
         {{- if .Values.user.values.enabled}}
-          - name: user-values-storage
-            persistentVolumeClaim:
-              claimName: meep-virt-engine-user-values-pvc
+        - name: user-values-storage
+          persistentVolumeClaim:
+            claimName: meep-virt-engine-user-values-pvc
         {{- end}}
         {{- if .Values.codecov.enabled}}
         - name: codecov-storage
@@ -58,8 +58,8 @@ spec:
             - name: data
               mountPath: /data/
             {{- if .Values.user.values.enabled}}
-              - name: user-values-storage
-                mountPath: {{ .Values.user.values.mountpath }}
+            - name: user-values-storage
+              mountPath: {{ .Values.user.values.mountpath }}
             {{- end}}
             {{- if .Values.codecov.enabled}}
             - name: codecov-storage

--- a/charts/meep-virt-engine/templates/user-values-pv.yaml
+++ b/charts/meep-virt-engine/templates/user-values-pv.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.user.values.enabled}}
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: meep-virt-engine-user-values-pv
+spec:
+  storageClassName: meep-virt-engine-user-values-sc
+  capacity:
+    storage: 100Mi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: {{ .Values.user.values.location }}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: meep-virt-engine-user-values-sc
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: meep-virt-engine-user-values-pvc
+spec:
+  storageClassName: meep-virt-engine-user-values-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+{{- end}}

--- a/charts/meep-virt-engine/values.yaml
+++ b/charts/meep-virt-engine/values.yaml
@@ -47,6 +47,13 @@ persistence:
   # storageClass: '-'
   storageClass: 'fullname'
 
+user:
+  values:
+    enabled: true
+    location: "<WORKDIR>/user/values"
+    mountpath: "/user-values"
+
+
 codecov:
   enabled: false
 

--- a/charts/open-map-tiles/values.yaml
+++ b/charts/open-map-tiles/values.yaml
@@ -12,9 +12,10 @@ image:
   pullPolicy: IfNotPresent
 
 service:
-  type: NodePort
+  type: ClusterIP
+  #type: NodePort
   port: 80
-  nodePort: 30080
+  #nodePort: 30080
 
 ingress:
   enabled: true

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -168,15 +168,15 @@ master:
   ## Redis Master Service properties
   service:
     ##  Redis Master Service type
-    # type: ClusterIP
-    type: NodePort
+    type: ClusterIP
+    #type: NodePort
     port: 6379
 
     ## Specify the nodePort value for the LoadBalancer and NodePort service types.
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
     ##
     # nodePort:
-    nodePort: 30379
+    #nodePort: 30379
 
     ## Provide any additional annotations which may be required. This can be used to
     ## set the LoadBalancer service type to internal only.

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -173,12 +173,6 @@ func deployCore(cobraCmd *cobra.Command) {
 	userValueDir := deployData.workdir + "/user/values"
 	for _, app := range deployData.coreApps {
 		chart := deployData.gitdir + "/" + utils.RepoCfg.GetString("repo.core.go-apps."+app+".chart")
-		userValues := false
-		userValueFile := userValueDir + "/" + app + ".yaml"
-		if _, err := os.Stat(userValueFile); err == nil {
-			// path/to/file exists
-			userValues = true
-		}
 		codecov := utils.RepoCfg.GetBool("repo.core.go-apps." + app + ".codecov")
 		userFe := utils.RepoCfg.GetBool("repo.deployment.user.frontend")
 		userSwagger := utils.RepoCfg.GetBool("repo.deployment.user.swagger")
@@ -200,15 +194,6 @@ func deployCore(cobraCmd *cobra.Command) {
 			// deployment level flag - not all apps use it
 			coreFlags = utils.HelmFlags(coreFlags, "--set", "user.swagger.enabled=true")
 			coreFlags = utils.HelmFlags(coreFlags, "--set", "user.swagger.location="+deployData.workdir+"/user/swagger")
-		}
-		if userValues {
-			// user provided overriding values
-			// Note: according to https://helm.sh/docs/chart_template_guide/values_files/
-			//       the order of precedence is: (lowest) default values.yaml
-			//                                            then user value file
-			//                                            then individual --set params (highest)
-			//       Therefore, the --set flags inserted by meepctl may interfere with user overrides
-			coreFlags = utils.HelmFlags(coreFlags, "-f", userValueFile)
 		}
 		if altServer {
 			// deployment level flag - not all apps use it

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -170,7 +170,6 @@ func deployCore(cobraCmd *cobra.Command) {
 	// Code coverage storage
 	deployCodeCovStorage(cobraCmd)
 
-	userValueDir := deployData.workdir + "/user/values"
 	for _, app := range deployData.coreApps {
 		chart := deployData.gitdir + "/" + utils.RepoCfg.GetString("repo.core.go-apps."+app+".chart")
 		codecov := utils.RepoCfg.GetBool("repo.core.go-apps." + app + ".codecov")

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -169,7 +170,7 @@ func deployCore(cobraCmd *cobra.Command) {
 	// Code coverage storage
 	deployCodeCovStorage(cobraCmd)
 
-	userValueDir := deployData.workdir+"/user/values"
+	userValueDir := deployData.workdir + "/user/values"
 	for _, app := range deployData.coreApps {
 		chart := deployData.gitdir + "/" + utils.RepoCfg.GetString("repo.core.go-apps."+app+".chart")
 		userValues := false
@@ -236,10 +237,9 @@ func deployDep(cobraCmd *cobra.Command) {
 
 func deployRunScriptsAndGetFlags(targetName string, chart string, cobraCmd *cobra.Command) [][]string {
 	var flags [][]string
-	flags := make([][]string, 0)
 
 	nodeIp := viper.GetString("node.ip")
-	userValueDir := deployData.workdir+"/user/values"
+	userValueDir := deployData.workdir + "/user/values"
 
 	userValueFile := userValueDir + "/" + targetName + ".yaml"
 	if _, err := os.Stat(userValueFile); err == nil {

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -296,6 +296,7 @@ func deployRunScriptsAndGetFlags(targetName string, chart string, cobraCmd *cobr
 	case "meep-virt-engine":
 		virtEngineTarget := "repo.core.go-apps.meep-virt-engine"
 		flags = utils.HelmFlags(flags, "--set", "persistence.location="+deployData.workdir+"/virt-engine")
+		flags = utils.HelmFlags(flags, "--set", "user.values.location="+deployData.workdir+"/user/values")
 		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_SANDBOX_PODS="+getPodList(virtEngineTarget+".sandbox-pods"))
 		flags = utils.HelmFlags(flags, "--set", "image.env.MEEP_HOST_URL=http://"+nodeIp)
 		altServer := utils.RepoCfg.GetBool("repo.deployment.alt-server")


### PR DESCRIPTION
Support user configuration value files for user specific deployments
- Added configuration params in repocfg.yaml
- meep-virt-engine : added PV for user values files & use file if present
- meepctl : use user value file if present
- supported by core, sandbox & dep 

Other
- Blocked un-necessary nodeports (couchdb, open-map-tiles, redis)
