### PR TITLE
Login session cookie fix on microservice restart

### DIFF
--- a/go-apps/meep-platform-ctrl/server/user_authentication.go
+++ b/go-apps/meep-platform-ctrl/server/user_authentication.go
@@ -100,14 +100,10 @@ func uaLoginUser(w http.ResponseWriter, r *http.Request) {
 	session, err := CookieStore.Get(r, "authCookie")
 	if err != nil {
 		log.Info(err.Error())
-		// Patch until encryption keys are persisted
-		// Try to renew the cookie
-		if session != nil {
-			session, err = CookieStore.New(r, "authCookie")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-		} else {
+		// Cookie decryption may fail on microservice restart due to
+		// mismatch with newly created cookie store encryption keys (no persistence).
+		// In this case use the newly generated session, if successfully created.
+		if session == nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
**CHANGES:**
- Platform-ctrl: fix to correctly create new session cookie if decryption fails due to microservice restart