### PR TITLE
Added initContainer for dependency check of DNS service in scenario pods

### DIFF
--- a/charts/meep-webhook/templates/configmap.yaml
+++ b/charts/meep-webhook/templates/configmap.yaml
@@ -12,3 +12,8 @@ data:
         capabilities:
           add:
             - NET_ADMIN
+    initContainers:
+    - name: init-{{ .Values.sidecar.dependency }}
+      image: busybox:1.28
+      imagePullPolicy: IfNotPresent
+      command: ['sh', '-c', 'until nslookup {{ .Values.sidecar.dependency }}.kube-system ; do echo waiting for {{ .Values.sidecar.dependency }}; sleep 0.25; done;']

--- a/charts/meep-webhook/values.yaml
+++ b/charts/meep-webhook/values.yaml
@@ -30,6 +30,7 @@ sidecar:
     repository: meep-docker-registry:30001/meep-tc-sidecar
     tag: latest
     pullPolicy: Always
+  dependency: kube-dns
 
 webhook:
   name: meep-webhook.idcc.com

--- a/go-apps/meep-webhook/webhook.go
+++ b/go-apps/meep-webhook/webhook.go
@@ -64,8 +64,9 @@ type WhSvrParameters struct {
 }
 
 type Config struct {
-	Containers []corev1.Container `yaml:"containers"`
-	Volumes    []corev1.Volume    `yaml:"volumes"`
+	Containers     []corev1.Container `yaml:"containers"`
+	Volumes        []corev1.Volume    `yaml:"volumes"`
+	InitContainers []corev1.Container `yaml:"initContainers"`
 }
 
 type patchOperation struct {
@@ -144,6 +145,11 @@ func getSidecarPatch(template corev1.PodTemplateSpec, sidecarConfig *Config, mee
 	patchOps = append(patchOps, addContainer(template.Spec.Containers, sidecarContainers, "/spec/template/spec/containers")...)
 	patchOps = append(patchOps, addVolume(template.Spec.Volumes, sidecarConfig.Volumes, "/spec/template/spec/volumes")...)
 	patchOps = append(patchOps, updateLabels(template.ObjectMeta.Labels, newLabels, "/spec/template/metadata/labels")...)
+
+	// Init Cointainer for dependency check
+	var initContainers []corev1.Container
+	initContainers = append(initContainers, sidecarConfig.InitContainers...)
+	patchOps = append(patchOps, addContainer(template.Spec.InitContainers, initContainers, "/spec/template/spec/initContainers")...)
 
 	// Serialize patch
 	patch, err = json.Marshal(patchOps)


### PR DESCRIPTION
Changes:
- Added InitContainer configuration to sidecarconfig file
- This change will work for Virt-Engine chats as well as User defined charts

Tests:
- Cypress and UT's passed
- Checked manual logs in containers after deploying demo1 and demo2 scenario