### PR TITLE
Fixed Net Char Event displays values without selecting an element

### DIFF
--- a/js-apps/meep-frontend/package.json
+++ b/js-apps/meep-frontend/package.json
@@ -8,7 +8,7 @@
     "test:verbose": "jest --verbose true",
     "test:coverage": "jest --verbose true --coverage --colors",
     "build": "webpack",
-    "build:dev": "webpack-dev-server --https true --port 8092 --host 10.3.16.105 --env.MEEP_HOST=10.3.16.105:8081"
+    "build:dev": "webpack-dev-server --https true --port 8092 --host 10.3.16.105 --env.MEEP_HOST=10.3.16.105"
   },
   "author": "",
   "license": "ISC",

--- a/js-apps/meep-frontend/src/js/containers/exec/event-creation-pane.js
+++ b/js-apps/meep-frontend/src/js/containers/exec/event-creation-pane.js
@@ -34,6 +34,7 @@ import {
 
 import {
   execChangeSelectedScenarioElement,
+  execResetSelectedScenarioElement,
   execUEs,
   execPOAs,
   execMobTypes,
@@ -117,9 +118,13 @@ class EventCreationPane extends Component {
   }
 
   updateElement(values) {
-    var element = updateObject({}, this.props.selectedScenarioElement);
-    element = updateObject(element, values);
-    this.props.changeSelectedScenarioElement(element);
+    if (values === null) {
+      this.props.resetSelectedScenarioElement();
+    } else {
+      var element = updateObject({}, this.props.selectedScenarioElement);
+      element = updateObject(element, values);
+      this.props.changeSelectedScenarioElement(element);
+    }
   }
 
   render() {
@@ -208,7 +213,8 @@ const mapDispatchToProps = dispatch => {
   return {
     changeEvent: event => dispatch(uiExecChangeCurrentEvent(event)),
     changeSelectedScenarioElement: element =>
-      dispatch(execChangeSelectedScenarioElement(element))
+      dispatch(execChangeSelectedScenarioElement(element)),
+    resetSelectedScenarioElement: () => dispatch(execResetSelectedScenarioElement())
   };
 };
 

--- a/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
+++ b/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
@@ -159,8 +159,10 @@ class NetworkCharacteristicsEventPane extends Component {
 
   onNetworkCharacPaneClose(e) {
     e.preventDefault();
-    this.onUpdateElement(FIELD_TYPE, '', null);
-    this.onUpdateElement(FIELD_NAME, '', null);
+    var updatedElem = updateObject({}, this.props.element);
+    setElemFieldVal(updatedElem, FIELD_NAME, '');
+    setElemFieldVal(updatedElem, FIELD_TYPE, '');
+    this.props.updateElement(updatedElem);
     this.props.onClose(e);
   }
 

--- a/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
+++ b/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
@@ -159,10 +159,7 @@ class NetworkCharacteristicsEventPane extends Component {
 
   onNetworkCharacPaneClose(e) {
     e.preventDefault();
-    var updatedElem = updateObject({}, this.props.element);
-    setElemFieldVal(updatedElem, FIELD_NAME, '');
-    setElemFieldVal(updatedElem, FIELD_TYPE, '');
-    this.props.updateElement(updatedElem);
+    this.props.updateElement(null);
     this.props.onClose(e);
   }
 

--- a/js-apps/meep-frontend/src/js/state/exec/selected-scenario-element.js
+++ b/js-apps/meep-frontend/src/js/state/exec/selected-scenario-element.js
@@ -19,6 +19,8 @@ import { createElem } from '../../util/elem-utils';
 
 const EXEC_CHANGE_SELECTED_SCENARIO_ELEMENT =
   'EXEC_CHANGE_SELECTED_SCENARIO_ELEMENT';
+const EXEC_RESET_SELECTED_SCENARIO_ELEMENT =
+  'EXEC_RESET_SELECTED_SCENARIO_ELEMENT';
 
 // CFG_SET_EDITED_ELEMENT
 function execChangeSelectedScenarioElement(element) {
@@ -28,7 +30,15 @@ function execChangeSelectedScenarioElement(element) {
   };
 }
 
-export { execChangeSelectedScenarioElement };
+// EXEC_RESET_ELEMENT
+function execResetSelectedScenarioElement() {
+  return {
+    type: EXEC_RESET_SELECTED_SCENARIO_ELEMENT,
+    payload: 'dummy'
+  };
+}
+
+export { execChangeSelectedScenarioElement, execResetSelectedScenarioElement };
 
 const initialState = createElem('dummy');
 
@@ -36,6 +46,8 @@ export function execSelectedScenarioElement(state = initialState, action) {
   switch (action.type) {
   case EXEC_CHANGE_SELECTED_SCENARIO_ELEMENT:
     return updateObject({}, action.payload);
+  case EXEC_RESET_SELECTED_SCENARIO_ELEMENT:
+    return createElem('dummy');
   default:
     return state;
   }


### PR DESCRIPTION
Changes:
- onUpdateElement was getting called separately for type and name, so the change in type was not happening because of timing delay.
So added separate code for updating it only once.
- Removed 8081 port for MEEP_HOST in package.json since it is not required now

Test:
- All UT's and Cypress test passed
- Manually checked, the old behaviour is not observed