### PR TITLE
Supporting Helm v3 Changes

### DIFF
--- a/charts/docker-registry/Chart.yaml
+++ b/charts/docker-registry/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 2.7.1
 description: A Helm chart for Docker Registry
 home: https://hub.docker.com/_/registry/

--- a/charts/grafana/Chart.yaml
+++ b/charts/grafana/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 6.5.2
 description: The leading tool for querying and visualizing time series and metrics.
 engine: gotpl

--- a/charts/influxdb/Chart.yaml
+++ b/charts/influxdb/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: influxdb
 version: 3.0.1
 appVersion: 1.7.6

--- a/charts/kube-state-metrics/Chart.yaml
+++ b/charts/kube-state-metrics/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: kube-state-metrics
 description: Install kube-state-metrics to generate and expose cluster-level metrics
 keywords:

--- a/charts/meep-gis-engine/Chart.yaml
+++ b/charts/meep-gis-engine/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP GIS Engine Helm chart for Kubernetes
 name: meep-gis-engine

--- a/charts/meep-loc-serv/Chart.yaml
+++ b/charts/meep-loc-serv/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP Location Service Helm chart for Kubernetes
 name: meep-loc-serv

--- a/charts/meep-metrics-engine/Chart.yaml
+++ b/charts/meep-metrics-engine/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP Metrics Engine Service Helm chart for Kubernetes
 name: meep-metrics-engine

--- a/charts/meep-mg-manager/Chart.yaml
+++ b/charts/meep-mg-manager/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP MG Manager Helm chart for Kubernetes
 name: meep-mg-manager

--- a/charts/meep-mon-engine/Chart.yaml
+++ b/charts/meep-mon-engine/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP Mon Engine Helm chart for Kubernetes
 name: meep-mon-engine

--- a/charts/meep-platform-ctrl/Chart.yaml
+++ b/charts/meep-platform-ctrl/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Meep Platform Controller Helm chart for Kubernetes
 name: meep-platform-ctrl

--- a/charts/meep-rnis/Chart.yaml
+++ b/charts/meep-rnis/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP Radio Network Information Service Helm chart for Kubernetes
 name: meep-rnis

--- a/charts/meep-sandbox-ctrl/Chart.yaml
+++ b/charts/meep-sandbox-ctrl/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Meep Sandbox Controller Helm chart for Kubernetes
 name: meep-sandbox-ctrl

--- a/charts/meep-tc-engine/Chart.yaml
+++ b/charts/meep-tc-engine/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP TC Engine Helm chart for Kubernetes
 name: meep-tc-engine

--- a/charts/meep-virt-chart-templates/Chart.yaml
+++ b/charts/meep-virt-chart-templates/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: A Helm chart for Kubernetes based on meep templates
 name: meep-templates

--- a/charts/meep-virt-engine/Chart.yaml
+++ b/charts/meep-virt-engine/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Meep Virtualization Engine Helm chart for Kubernetes
 name: meep-virt-engine

--- a/charts/meep-webhook/Chart.yaml
+++ b/charts/meep-webhook/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: MEEP Admission Webhook Helm chart for Kubernetes
 name: meep-webhook

--- a/charts/nginx-ingress/Chart.yaml
+++ b/charts/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 0.30.0
 description: An nginx Ingress controller that uses ConfigMap to store the nginx configuration.
 engine: gotpl

--- a/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/nginx-ingress/templates/_helpers.tpl
@@ -87,7 +87,7 @@ Create the name of the backend service account to use - only used when podsecuri
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
-{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1" -}}
 {{- else -}}
 {{- print "extensions/v1beta1" -}}
@@ -98,7 +98,7 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiGroup for PodSecurityPolicy.
 */}}
 {{- define "podSecurityPolicy.apiGroup" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "policy" -}}
 {{- else -}}
 {{- print "extensions" -}}
@@ -109,7 +109,7 @@ Return the appropriate apiGroup for PodSecurityPolicy.
 Return the appropriate apiVersion for podSecurityPolicy.
 */}}
 {{- define "podSecurityPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.10-0" .Capabilities.KubeVersion.Version -}}
 {{- print "policy/v1beta1" -}}
 {{- else -}}
 {{- print "extensions/v1beta1" -}}

--- a/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/nginx-ingress/templates/controller-service.yaml
@@ -35,13 +35,13 @@ spec:
   loadBalancerSourceRanges:
 {{ toYaml .Values.controller.service.loadBalancerSourceRanges | indent 4 }}
 {{- end }}
-{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.externalTrafficPolicy) }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.externalTrafficPolicy) }}
   externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
 {{- end }}
 {{- if .Values.controller.service.sessionAffinity }}
   sessionAffinity: "{{ .Values.controller.service.sessionAffinity }}"
 {{- end }}
-{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.service.healthCheckNodePort) }}
+{{- if and (semverCompare ">=1.7-0" .Capabilities.KubeVersion.Version) (.Values.controller.service.healthCheckNodePort) }}
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
 {{- end }}
   ports:

--- a/charts/open-map-tiles/Chart.yaml
+++ b/charts/open-map-tiles/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: open-map-tiles

--- a/charts/postgis/Chart.yaml
+++ b/charts/postgis/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: postgis
 version: 8.9.5
 appVersion: 11.7.0

--- a/charts/postgis/templates/_helpers.tpl
+++ b/charts/postgis/templates/_helpers.tpl
@@ -40,9 +40,9 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "postgresql.networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.Version -}}
 "extensions/v1beta1"
-{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.Version -}}
 "networking.k8s.io/v1"
 {{- end -}}
 {{- end -}}
@@ -395,7 +395,7 @@ Usage:
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "postgresql.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -444,7 +444,7 @@ postgresql: psp.create, rbac.create
 Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "podsecuritypolicy.apiVersion" -}}
-{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.10-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -35,7 +35,7 @@ If release name contains chart name it will be used as a full name.
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "networkPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.Version -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}

--- a/examples/demo2/charts/iperf/Chart.yaml
+++ b/examples/demo2/charts/iperf/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Meep Demo Iperf Helm chart for Kubernetes
 name: demo-iperf

--- a/examples/demo2/charts/svc/Chart.yaml
+++ b/examples/demo2/charts/svc/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0.0"
 description: Meep Demo Service Helm chart for Kubernetes
 name: demo-svc

--- a/go-apps/meep-virt-engine/Dockerfile
+++ b/go-apps/meep-virt-engine/Dockerfile
@@ -25,11 +25,11 @@ COPY ./meep-virt-chart-templates /templates/scenario/meep-virt-chart-templates
 COPY ./entrypoint.sh /entrypoint.sh
 COPY ./meep-virt-engine /meep-virt-engine
 
-ENV HELM_VERSION="v2.16.1"
+ENV HELM_VERSION="v3.3.1"
 RUN mkdir -p /active \
     && apt-get update \
     && apt-get install -y wget \
-    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm \
     && chmod +x /entrypoint.sh
 

--- a/go-apps/meep-virt-engine/entrypoint.sh
+++ b/go-apps/meep-virt-engine/entrypoint.sh
@@ -2,7 +2,6 @@
 set -e
 
 # Configure & update helm repo
-helm init --client-only
 helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 helm repo update
 

--- a/go-apps/meep-virt-engine/helm/delete.go
+++ b/go-apps/meep-virt-engine/helm/delete.go
@@ -31,8 +31,8 @@ func deleteReleases(charts []Chart) error {
 }
 
 func deleteRelease(chart Chart) {
-	log.Debug("Deleting release: " + chart.ReleaseName)
-	var cmd = exec.Command("helm", "delete", chart.ReleaseName, "--purge")
+	log.Debug("Deleting release: ", chart.ReleaseName, ", Namespace: ", chart.Namespace)
+	var cmd = exec.Command("helm", "uninstall", chart.ReleaseName, "-n", chart.Namespace)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Error("Chart couldn't be released: ", string(out), "---", err)

--- a/go-apps/meep-virt-engine/helm/helm.go
+++ b/go-apps/meep-virt-engine/helm/helm.go
@@ -20,8 +20,11 @@ func GetReleasesName() ([]Release, error) {
 	return getReleasesName()
 }
 
-// currently GetReleases is not used. Since it uses helm status and helmv3 doesn't show resources
-// https://github.com/helm/helm/issues/5952 
+/*
+* currently GetReleases is not used. Since it uses helm status and helmv3 doesn't show resources
+* https://github.com/helm/helm/issues/5952
+ */
+
 func GetReleases() ([]Release, error) {
 	return getReleases()
 }

--- a/go-apps/meep-virt-engine/helm/helm.go
+++ b/go-apps/meep-virt-engine/helm/helm.go
@@ -20,6 +20,8 @@ func GetReleasesName() ([]Release, error) {
 	return getReleasesName()
 }
 
+// currently GetReleases is not used. Since it uses helm status and helmv3 doesn't show resources
+// https://github.com/helm/helm/issues/5952 
 func GetReleases() ([]Release, error) {
 	return getReleases()
 }

--- a/go-apps/meep-virt-engine/helm/install.go
+++ b/go-apps/meep-virt-engine/helm/install.go
@@ -61,16 +61,14 @@ func install(chart Chart) error {
 	log.Debug("Installing chart: " + chart.ReleaseName)
 	var cmd *exec.Cmd
 	if strings.Trim(chart.ValuesFile, " ") == "" {
-		cmd = exec.Command("helm", "install",
-			"--name", chart.ReleaseName,
-			"--namespace", chart.Namespace,
+		cmd = exec.Command("helm", "install", chart.ReleaseName,
+			"--namespace", chart.Namespace, "--create-namespace",
 			"--set", "nameOverride="+chart.Name,
 			"--set", "fullnameOverride="+chart.Name,
-			chart.Location, "--replace")
+			chart.Location, "--replace", "--disable-openapi-validation")
 	} else {
-		cmd = exec.Command("helm", "install",
-			"--name", chart.ReleaseName,
-			"--namespace", chart.Namespace,
+		cmd = exec.Command("helm", "install", chart.ReleaseName,
+			"--namespace", chart.Namespace, "--create-namespace",
 			"--set", "nameOverride="+chart.Name,
 			"--set", "fullnameOverride="+chart.Name,
 			"-f", chart.ValuesFile,

--- a/go-apps/meep-virt-engine/helm/list.go
+++ b/go-apps/meep-virt-engine/helm/list.go
@@ -52,7 +52,7 @@ func getReleases() ([]Release, error) {
 }
 
 func getList() ([]byte, error) {
-	var cmd = exec.Command("helm", "ls")
+	var cmd = exec.Command("helm", "ls", "-A")
 	out, err := cmd.Output()
 	if err != nil {
 		err = errors.New("Unable to list Releases")

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -297,6 +297,7 @@ func deleteReleases(sandboxName string, scenarioName string) (error, int) {
 			if strings.HasPrefix(rel.Name, releasePrefix) {
 				var c helm.Chart
 				c.ReleaseName = rel.Name
+				c.Namespace = sandboxName
 				toDelete = append(toDelete, c)
 			}
 		}

--- a/go-apps/meepctl/cmd/version.go
+++ b/go-apps/meepctl/cmd/version.go
@@ -179,8 +179,7 @@ func versionsDep(cobraCmd *cobra.Command) {
 }
 
 func getHelmVersion(cobraCmd *cobra.Command) {
-	clientStr := formatVersion("helm client", na, "", "")
-	serverStr := formatVersion("helm server", na, "", "")
+	helmStr := formatVersion("helm", na, "", "")
 	cmd := exec.Command("helm", "version")
 	output, err := utils.ExecuteCmd(cmd, cobraCmd)
 	if err != nil {
@@ -188,18 +187,12 @@ func getHelmVersion(cobraCmd *cobra.Command) {
 	} else {
 		output = strings.Replace(output, "\"", "", -1)
 		outAll := strings.Split(output, "}")
-		outClient := outAll[0]
-		outServer := outAll[1]
-		//client part
-		out := strings.Split(outClient, ",")
-		clientStr = formatVersion("helm client", strings.Split(out[0], ":")[2], strings.Split(out[1], ":")[1], "")
-		//server part
-		out = strings.Split(outServer, ",")
-		serverStr = formatVersion("helm server", strings.Split(out[0], ":")[2], strings.Split(out[1], ":")[1], "")
+		outVersion := outAll[0]
+		out := strings.Split(outVersion, ",")
+		helmStr = formatVersion("helm", strings.Split(out[0], ":")[1], strings.Split(out[1], ":")[1], "")
 	}
 
-	fmt.Println(clientStr)
-	fmt.Println(serverStr)
+	fmt.Println(helmStr)
 }
 
 func getDockerVersion(cobraCmd *cobra.Command) {

--- a/go-apps/meepctl/utils/helm.go
+++ b/go-apps/meepctl/utils/helm.go
@@ -33,7 +33,7 @@ func IsHelmRelease(name string, cobraCmd *cobra.Command) (exist bool, err error)
 	verbose, _ := cobraCmd.Flags().GetBool("verbose")
 
 	start := time.Now()
-	cmd := exec.Command("helm", "ls", name, "--short")
+	cmd := exec.Command("helm", "ls", "--filter", name, "--short")
 	if verbose {
 		fmt.Println("Cmd:", cmd.Args)
 	}
@@ -61,7 +61,7 @@ func HelmDelete(name string, cobraCmd *cobra.Command) (err error) {
 	verbose, _ := cobraCmd.Flags().GetBool("verbose")
 
 	start := time.Now()
-	cmd := exec.Command("helm", "delete", name, "--purge")
+	cmd := exec.Command("helm", "uninstall", name)
 	if verbose {
 		fmt.Println("Cmd:", cmd.Args)
 	}
@@ -88,7 +88,7 @@ func HelmInstall(name string, chart string, flags [][]string, cobraCmd *cobra.Co
 	verbose, _ := cobraCmd.Flags().GetBool("verbose")
 
 	start := time.Now()
-	cmd := exec.Command("helm", "install", "--name", name, "--set", "fullnameOverride="+name, chart, "--replace")
+	cmd := exec.Command("helm", "install", name, "--set", "fullnameOverride="+name, chart, "--replace")
 	for _, f := range flags {
 		cmd.Args = append(cmd.Args, f[0])
 		cmd.Args = append(cmd.Args, f[1])

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -15,7 +15,7 @@ network_dir: /etc/kubernetes/network
 kubeadmin_config: /etc/kubernetes/admin.conf
 
 # Helm
-helm_version: "2.16/stable"
+helm_version: "3.3/stable"
 
 # Go
 #go_version: "1.13.12"

--- a/playbooks/roles/helm/tasks/install.yml
+++ b/playbooks/roles/helm/tasks/install.yml
@@ -7,31 +7,6 @@
     channel: "{{ helm_version }}"
     state: present
 
-- name: "Install tiller"
-  shell: "helm init --kubeconfig .kube/config"
-  tags: helm
-
-- name: "Configure tiller"
-  shell: "kubectl create serviceaccount tiller --namespace kube-system --kubeconfig .kube/config"
-  tags: helm
-  ignore_errors: yes
-
-- name: "Copy yaml file"
-  copy:
-    src: "tiller-crb.yaml"
-    dest: "tiller-crb.yaml"
-    mode: 0644
-  tags: helm
-
-- name: "Create tiller cluster role binding"
-  shell: "kubectl create -f tiller-crb.yaml --kubeconfig .kube/config"
-  tags: helm
-  ignore_errors: yes
-
-- name: "Re-initialize tiller with crb"
-  shell: "helm init --service-account tiller --upgrade --kubeconfig .kube/config"
-  tags: helm
-
 - name: "Enable incubator charts"
   shell: "helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/ --kubeconfig .kube/config"
   tags: helm

--- a/test/start-ut-env.sh
+++ b/test/start-ut-env.sh
@@ -10,7 +10,7 @@ echo ">>> Installing redis DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-redis --set meepOrigin="ut" --set master.service.type=NodePort --set master.service.nodePort=30380 $BASEDIR/../charts/redis/
+helm install meep-ut-redis --set meepOrigin="ut" --set master.service.type=NodePort --set master.service.nodePort=30380 $BASEDIR/../charts/redis/
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
@@ -18,7 +18,7 @@ echo ">>> Installing couch DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-couchdb --set meepOrigin="ut" --set service.type=NodePort --set service.nodePort=30985 --set persistentVolume.enabled=false --set persistentVolumeClaim.enabled=false $BASEDIR/../charts/couchdb/
+helm install meep-ut-couchdb --set meepOrigin="ut" --set service.type=NodePort --set service.nodePort=30985 --set persistentVolume.enabled=false --set persistentVolumeClaim.enabled=false $BASEDIR/../charts/couchdb/
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
@@ -26,7 +26,7 @@ echo ">>> Installing influx DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-influxdb --set meepOrigin="ut" --set service.type=NodePort --set service.apiNodePort=30986 --set service.rpcNodePort=30988 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/influxdb/
+helm install meep-ut-influxdb --set meepOrigin="ut" --set service.type=NodePort --set service.apiNodePort=30986 --set service.rpcNodePort=30988 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/influxdb/
 
 echo ""
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
@@ -34,4 +34,4 @@ echo ">>> Installing Postgis DB for Unit Testing"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm install --name meep-ut-postgis --set meepOrigin="ut" --set securityContext.enabled=false --set master.service.type=NodePort --set master.service.nodePort=30432 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/postgis/
+helm install meep-ut-postgis --set meepOrigin="ut" --set securityContext.enabled=false --set master.service.type=NodePort --set master.service.nodePort=30432 --set persistence.enabled=false --set ingress.enabled=false $BASEDIR/../charts/postgis/

--- a/test/stop-ut-env.sh
+++ b/test/stop-ut-env.sh
@@ -10,4 +10,4 @@ echo ">>> Stopping UT environment"
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo ""
 
-helm ls --short | grep meep-ut | xargs -L1 helm delete --purge
+helm ls --short | grep meep-ut | xargs -L1 helm uninstall


### PR DESCRIPTION
Changes:
- Changed Chart apiVersion to v2 from v1
- Changed .Capabilities.KubeVersion.GitVersion to .Capabilities.KubeVersion.Version
- Changes in helm install, delete, list v2 commands to v3
- Disabled OpenAPI validation in helm install for scenario and sandbox pods
- Changed helm version from 2.16.1 to 3.3.1, updated download link and snap helm command
- Removed helm init from virt-engine and ansible
- Changes in helm version parsing code

Testing:
- Manually tested creating and deleting sandbox, deploying and terminating demo1 and demo2 scenario
- All UT's and Cypress tests passed

https://helm.sh/docs/faq
https://helm.sh/docs/topics/v2_v3_migration/