### PR TITLE
AdvantEDGE services handling of UE movement between different RAT (4G, 5G, Wifi)

### DIFF
--- a/go-apps/meep-rnis/api/swagger.yaml
+++ b/go-apps/meep-rnis/api/swagger.yaml
@@ -2899,7 +2899,6 @@ definitions:
     type: "object"
     required:
     - "appInsId"
-    - "ecgi"
     properties:
       timeStamp:
         $ref: "#/definitions/TimeStamp"
@@ -2908,8 +2907,8 @@ definitions:
         format: "string"
         example: "01"
         description: "Unique identifier for the mobile edge application instance"
-      ecgi:
-        $ref: "#/definitions/Ecgi"
+      plmn:
+        $ref: "#/definitions/Plmn"
   RabInfo:
     type: "object"
     required:

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -216,9 +216,8 @@ func processActiveScenarioUpdate() {
 								cellId = poa.Poa5GConfig.CellId
 							}
 						}
-					case mod.NodeTypePoaWifi:
-						cellId = ""
 					default:
+						//empty cells for POAs not supporting RNIS
 						cellId = ""
 					}
 
@@ -288,9 +287,8 @@ func processActiveScenarioUpdate() {
 									cellId = nl.Poa5GConfig.CellId
 								}
 							}
-						case mod.NodeTypePoaWifi:
-							cellId = ""
 						default:
+							//empty cells for POAs not supporting RNIS
 							cellId = ""
 						}
 

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -218,6 +218,8 @@ func processActiveScenarioUpdate() {
 						}
 					case mod.NodeTypePoaWifi:
 						cellId = ""
+					default:
+						cellId = ""
 					}
 
 					sbi.updateUeDataCB(name, mnc, mcc, cellId, erabIdValid)
@@ -287,6 +289,8 @@ func processActiveScenarioUpdate() {
 								}
 							}
 						case mod.NodeTypePoaWifi:
+							cellId = ""
+						default:
 							cellId = ""
 						}
 

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -238,7 +238,7 @@ func processActiveScenarioUpdate() {
 			}
 		}
 		if !found {
-			sbi.updateUeDataCB(prevUeName, "", "", "", -1)
+			sbi.updateUeDataCB(prevUeName, "", "", "", false)
 			log.Info("Ue removed : ", prevUeName)
 		}
 	}

--- a/go-apps/meep-rnis/server/model_plmn_info.go
+++ b/go-apps/meep-rnis/server/model_plmn_info.go
@@ -29,5 +29,5 @@ type PlmnInfo struct {
 	// Unique identifier for the mobile edge application instance
 	AppInsId string `json:"appInsId"`
 
-	Ecgi *Ecgi `json:"ecgi"`
+	Plmn *Plmn `json:"plmn,omitempty"`
 }

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -253,13 +253,10 @@ func updateUeData(name string, mnc string, mcc string, cellId string, erabIdVali
 		//log to model for all apps on that UE
 		checkCcNotificationRegisteredSubscriptions("", assocId, &plmn, oldPlmn, "", cellId, oldCellId)
 		//ueData contains newErabId
-		log.Info("TEST SIMON")
 		if oldErabId == -1 && ueData.ErabId != -1 {
-			log.Info("SIMON")
 			checkReNotificationRegisteredSubscriptions("", assocId, &plmn, oldPlmn, -1, cellId, oldCellId, ueData.ErabId)
 		}
 		if oldErabId != -1 && ueData.ErabId == -1 {
-			log.Info("SIMON2")
 			checkRrNotificationRegisteredSubscriptions("", assocId, &plmn, oldPlmn, -1, cellId, oldCellId, ueData.ErabId)
 		}
 	}
@@ -551,11 +548,6 @@ func checkCcNotificationRegisteredSubscriptions(appId string, assocId *Associate
 
 func checkReNotificationRegisteredSubscriptions(appId string, assocId *AssociateId, newPlmn *Plmn, oldPlmn *Plmn, qci int32, newCellId string, oldCellId string, erabId int32) {
 
-	//only applies if coming from a non 3gpp element
-	//	if oldCellId != "" || newCellId == "" {
-	//		return
-	//	}
-
 	//check all that applies
 	for subsId, sub := range reSubscriptionMap {
 
@@ -647,11 +639,6 @@ func checkReNotificationRegisteredSubscriptions(appId string, assocId *Associate
 }
 
 func checkRrNotificationRegisteredSubscriptions(appId string, assocId *AssociateId, newPlmn *Plmn, oldPlmn *Plmn, qci int32, newCellId string, oldCellId string, erabId int32) {
-
-	//only applies if going to a non 3gpp element
-	//	if newCellId != "" || oldCellId == "" {
-	//		return
-	//	}
 
 	//check all that applies
 	for subsId, sub := range rrSubscriptionMap {

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -230,18 +230,21 @@ func updateUeData(name string, mnc string, mcc string, cellId string, erabIdVali
 	//updateDB if changes occur
 	if newEcgi.Plmn.Mnc != oldPlmnMnc || newEcgi.Plmn.Mcc != oldPlmnMcc || newEcgi.CellId != oldCellId {
 
-		//allocating a new erabId if entering a 4G environment (existence of an erabId)
-		if oldErabId == -1 && erabIdValid {
-			//rab establishment case
-			ueData.ErabId = int32(nextAvailableErabId)
-			nextAvailableErabId++
+		//allocating a new erabId if entering a 4G environment (using existence of an erabId)
+		if oldErabId == -1 { //if no erabId established (== -1), means not coming from a 4G environment
+			if erabIdValid { //if a new erabId should be allocated (meaning entering into a 4G environment)
+				//rab establishment case
+				ueData.ErabId = int32(nextAvailableErabId)
+				nextAvailableErabId++
+			} else { //was not connected to a 4G POA and still not connected to a 4G POA, so, no change
+				ueData.ErabId = oldErabId // = -1
+			}
 		} else {
-			if oldErabId != -1 && !erabIdValid {
+			if erabIdValid { //was connected to a 4G POA and still is, so, no change
+				ueData.ErabId = oldErabId // = sameAsBefore
+			} else { //was connected to a 4G POA, but now not connected to one, so need to release the 4G connection
 				//rab release case
 				ueData.ErabId = -1
-			} else {
-				//no change
-				ueData.ErabId = oldErabId
 			}
 		}
 

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -2268,11 +2268,8 @@ func TestPlmnInfoGet(t *testing.T) {
 	 * expected response section
 	 ******************************/
 	var expectedMcc [2]string
-	var expectedCellId [2]string
 	expectedMcc[INITIAL] = "123"
 	expectedMcc[UPDATED] = "123"
-	expectedCellId[INITIAL] = "2345678"
-	expectedCellId[UPDATED] = "1234567"
 
 	/******************************
 	 * request vars section
@@ -2305,10 +2302,7 @@ func TestPlmnInfoGet(t *testing.T) {
 	}
 
 	if respBody.PlmnInfo != nil {
-		if respBody.PlmnInfo[0].Ecgi.Plmn.Mcc != expectedMcc[INITIAL] {
-			t.Fatalf("Failed to get expected response")
-		}
-		if respBody.PlmnInfo[0].Ecgi.CellId != expectedCellId[INITIAL] {
+		if respBody.PlmnInfo[0].Plmn.Mcc != expectedMcc[INITIAL] {
 			t.Fatalf("Failed to get expected response")
 		}
 	} else {
@@ -2326,10 +2320,7 @@ func TestPlmnInfoGet(t *testing.T) {
 		t.Fatalf("Failed to get expected response")
 	}
 	if respBody.PlmnInfo != nil {
-		if respBody.PlmnInfo[0].Ecgi.Plmn.Mcc != expectedMcc[UPDATED] {
-			t.Fatalf("Failed to get expected response")
-		}
-		if respBody.PlmnInfo[0].Ecgi.CellId != expectedCellId[UPDATED] {
+		if respBody.PlmnInfo[0].Plmn.Mcc != expectedMcc[UPDATED] {
 			t.Fatalf("Failed to get expected response")
 		}
 	} else {

--- a/go-packages/meep-rnis-client/api/swagger.yaml
+++ b/go-packages/meep-rnis-client/api/swagger.yaml
@@ -2899,7 +2899,6 @@ definitions:
     type: "object"
     required:
     - "appInsId"
-    - "ecgi"
     properties:
       timeStamp:
         $ref: "#/definitions/TimeStamp"
@@ -2908,8 +2907,8 @@ definitions:
         format: "string"
         example: "01"
         description: "Unique identifier for the mobile edge application instance"
-      ecgi:
-        $ref: "#/definitions/Ecgi"
+      plmn:
+        $ref: "#/definitions/Plmn"
   RabInfo:
     type: "object"
     required:

--- a/go-packages/meep-rnis-client/docs/PlmnInfo.md
+++ b/go-packages/meep-rnis-client/docs/PlmnInfo.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **TimeStamp** | [***TimeStamp**](TimeStamp.md) |  | [optional] [default to null]
 **AppInsId** | **string** | Unique identifier for the mobile edge application instance | [default to null]
-**Ecgi** | [***Ecgi**](Ecgi.md) |  | [default to null]
+**Plmn** | [***Plmn**](Plmn.md) |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go-packages/meep-rnis-client/model_plmn_info.go
+++ b/go-packages/meep-rnis-client/model_plmn_info.go
@@ -27,5 +27,5 @@ type PlmnInfo struct {
 	TimeStamp *TimeStamp `json:"timeStamp,omitempty"`
 	// Unique identifier for the mobile edge application instance
 	AppInsId string `json:"appInsId"`
-	Ecgi     *Ecgi  `json:"ecgi"`
+	Plmn     *Plmn  `json:"plmn,omitempty"`
 }

--- a/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
+++ b/js-apps/meep-frontend/src/js/containers/cfg/cfg-network-element-container.js
@@ -333,8 +333,8 @@ const validateCellularCellId = val => {
 
 const validateCellularNrCellId = val => {
   if (val) {
-    if (val.length > 7) {
-      return 'Maximum 7 characters';
+    if (val.length > 9) {
+      return 'Maximum 9 characters';
     } else if (!val.match(/^(([_a-f0-9A-F][_-a-f0-9]*)?[_a-f0-9A-F])+$/)) {
       return 'Alphanumeric hex characters only';
     }


### PR DESCRIPTION
Support for the following events in Services mentioned below:

Location Service
1) - POA change using the name of the element. Valid for all poa types (4G, 5G, Wifi)

RNIS
2) - cell change only within poa-4G and poa-5G elements
3) - rab-establishment when going from poa-5G or Wifi to poa-4G
4) - rab-release when going to poa-5G or Wifi from poa-4G

5) PLMNInfo GET updated to only display the PLMN, no cellId

Tested using a scenario mixed with all types within different zones.