### PR TITLE
user-chart folder creation and demo2 documentation update

### DIFF
--- a/examples/demo2/README.md
+++ b/examples/demo2/README.md
@@ -25,6 +25,7 @@ cd ~/AdvantEDGE/examples/demo2/
 ##### Import
 
 To import demo2 follow steps given for demo1 just import demo2-scenario.yaml from AdvantEDGE/examples/demo2/ instead of demo1-scenario.yaml:
+
 [Import scenario in AdvantEDGE](https://github.com/InterDigitalInc/AdvantEDGE/wiki/basic-operation#import-demo1-scenario-in-advantedge)
 
 
@@ -32,4 +33,5 @@ To import demo2 follow steps given for demo1 just import demo2-scenario.yaml fro
 ##### Deploy
 
 To deploy demo2 follow steps given for demo1 just select demo2 from dropdown instead of demo:
+
 [Deploy scenario in AdvantEDGE](https://github.com/InterDigitalInc/AdvantEDGE/wiki/basic-operation#deploy-demo1-scenario)

--- a/examples/demo2/README.md
+++ b/examples/demo2/README.md
@@ -11,6 +11,25 @@ This scenario is the same as [demo1](../demo1/README.md) except that it uses _us
 
 ## Using the scenario
 
-- [Import scenario in AdvantEDGE](https://github.com/InterDigitalInc/AdvantEDGE/wiki/basic-operation#import-demo1-scenario-in-advantedge)
-- Deploy scenario
-  - Scenario behavior is identical to [demo1](../demo1/README.md)
+The following steps need to be done prior to using this scenario
+
+##### Build
+
+To build demo2:
+
+```
+cd ~/AdvantEDGE/examples/demo2/
+./build-demo2.sh
+```
+
+##### Import
+
+To import demo2 follow steps given for demo1 just import demo2-scenario.yaml from AdvantEDGE/examples/demo2/ instead of demo1-scenario.yaml:
+[Import scenario in AdvantEDGE](https://github.com/InterDigitalInc/AdvantEDGE/wiki/basic-operation#import-demo1-scenario-in-advantedge)
+
+
+
+##### Deploy
+
+To deploy demo2 follow steps given for demo1 just select demo2 from dropdown instead of demo:
+[Deploy scenario in AdvantEDGE](https://github.com/InterDigitalInc/AdvantEDGE/wiki/basic-operation#deploy-demo1-scenario)

--- a/examples/demo2/build-demo2.sh
+++ b/examples/demo2/build-demo2.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Get full path to script directory
+SCRIPT=$(readlink -f "$0")
+BASEDIR=$(dirname "$SCRIPT")
+cd $BASEDIR
+
+# Retrieve workdir
+WORKDIR=`grep workdir $HOME/.meepctl.yaml | sed 's/^.*workdir:[ \t]*//'`
+DEMO2DIR=${WORKDIR}/virt-engine/user-charts/demo2
+
+# Copy demo charts to workdir
+mkdir -p ${DEMO2DIR}
+cp -r ./charts ${DEMO2DIR}
+cp -r ./values ${DEMO2DIR}
+
+echo ">>> Demo2 build completed"

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -156,6 +156,7 @@ func deployEnsureStorage(cobraCmd *cobra.Command) {
 	cmd.Args = append(cmd.Args, deployData.workdir+"/influxdb")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/tmp")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/virt-engine")
+	cmd.Args = append(cmd.Args, deployData.workdir+"/virt-engine/user-charts")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/omt")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/postgis")
 	_, err := utils.ExecuteCmd(cmd, cobraCmd)


### PR DESCRIPTION
Changes:
- Added code to add user-charts folder in ~/.meep/virt-engine as part of deploy process
- Create new file to build demo2 which will copy demo2 to ~/.meep/virt-engine/
- Updated demo2 documentation

Tests:
- All UT's and cypress tests passed
- Manual testing of demo2 worked correctly