### PR TITLE
beta sandbox fixes for services

### DIFF
--- a/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
+++ b/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
@@ -221,8 +221,8 @@ func processActiveScenarioUpdate() {
 		}
 	}
 
-	// Update POA Cellular info
-	poaNameList := sbi.activeModel.GetNodeNames(mod.NodeTypePoa4G, mod.NodeTypePoa5G)
+	// Update POA Cellular and Wifi info
+	poaNameList := sbi.activeModel.GetNodeNames(mod.NodeTypePoa4G, mod.NodeTypePoa5G, mod.NodeTypePoaWifi)
 	for _, name := range poaNameList {
 		zone, netLoc, err := getNetworkLocation(name)
 		if err != nil {

--- a/go-apps/meep-rnis/api/swagger.yaml
+++ b/go-apps/meep-rnis/api/swagger.yaml
@@ -201,7 +201,7 @@ paths:
       - name: "app_ins_id"
         in: "query"
         description: "Application instance identifier"
-        required: true
+        required: false
         type: "array"
         items:
           type: "string"
@@ -4047,7 +4047,7 @@ parameters:
     name: "app_ins_id"
     in: "query"
     description: "Application instance identifier"
-    required: true
+    required: false
     type: "array"
     items:
       type: "string"

--- a/go-apps/meep-rnis/server/README.md
+++ b/go-apps/meep-rnis/server/README.md
@@ -13,7 +13,7 @@ To see how to make this your own, look here:
 [README](https://github.com/swagger-api/swagger-codegen/blob/master/README.md)
 
 - API version: 1.1.1
-- Build date: 2020-09-25T11:33:31.932-04:00
+- Build date: 2020-10-01T11:00:47.023-04:00
 
 
 ### Running the server

--- a/go-apps/meep-rnis/server/convert.go
+++ b/go-apps/meep-rnis/server/convert.go
@@ -66,6 +66,28 @@ func convertUeDataToJson(obj *UeData) string {
 	return string(jsonData)
 }
 
+func convertJsonToDomainData(jsonData string) *DomainData {
+
+	var obj DomainData
+	err := json.Unmarshal([]byte(jsonData), &obj)
+	if err != nil {
+		log.Error(err.Error())
+		return nil
+	}
+	return &obj
+}
+
+func convertDomainDataToJson(obj *DomainData) string {
+
+	jsonData, err := json.Marshal(*obj)
+	if err != nil {
+		log.Error(err.Error())
+		return ""
+	}
+
+	return string(jsonData)
+}
+
 func convertJsonToCellChangeSubscription(jsonInfo string) *CellChangeSubscription {
 
 	var obj CellChangeSubscription

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -622,14 +622,32 @@ func populateApInfo(key string, jsonInfo string, response interface{}) error {
 		return err
 	}
 
-	seconds := time.Now().Unix()
-	var timeStamp TimeStamp
-	timeStamp.Seconds = int32(seconds)
+	//timeStamp is optional, commenting the code
+	//seconds := time.Now().Unix()
+	//var timeStamp TimeStamp
+	//timeStamp.Seconds = int32(seconds)
 
 	var apInfo ApInfo
-	apInfo.TimeStamp = &timeStamp
+	//apInfo.TimeStamp = &timeStamp
 
 	apInfo.ApId = &apInfoComplete.ApId
+
+	var bssLoad BssLoad
+	bssLoad.StaCount = int32(len(apInfoComplete.StaMacIds))
+	bssLoad.ChannelUtilization = 0
+	bssLoad.AvailAdmCap = 0
+	apInfo.BssLoad = &bssLoad
+
+	var apLocation ApLocation
+	var geoLocation GeoLocation
+	if apInfoComplete.ApLocation.GeoLocation != nil {
+		geoLocation.Lat = apInfoComplete.ApLocation.GeoLocation.Lat
+		geoLocation.Long = apInfoComplete.ApLocation.GeoLocation.Long
+		geoLocation.Datum = 1
+		apLocation.GeoLocation = &geoLocation
+		apInfo.ApLocation = &apLocation
+	}
+
 	resp.ApInfo = append(resp.ApInfo, apInfo)
 
 	return nil
@@ -676,12 +694,13 @@ func populateStaInfo(key string, jsonInfo string, response interface{}) error {
 	//if not connected to any wifi poa, ignore
 	if ueData.ApMacId != "" {
 
-		seconds := time.Now().Unix()
-		var timeStamp TimeStamp
-		timeStamp.Seconds = int32(seconds)
+		//timeStamp is optional, commenting the code
+		//seconds := time.Now().Unix()
+		//var timeStamp TimeStamp
+		//timeStamp.Seconds = int32(seconds)
 
 		var staInfo StaInfo
-		staInfo.TimeStamp = &timeStamp
+		//staInfo.TimeStamp = &timeStamp
 
 		var staId StaIdentity
 		staId.MacId = ueData.OwnMacId
@@ -692,8 +711,8 @@ func populateStaInfo(key string, jsonInfo string, response interface{}) error {
 		staInfo.ApAssociated = &apAssociated
 
 		//TODO put a value in rssi that is coming from postGIS
-		log.Info("TODO forced RSSI")
-		staInfo.Rssi = 121
+		//log.Info("TODO forced RSSI")
+		//staInfo.Rssi = 121
 
 		resp.StaInfo = append(resp.StaInfo, staInfo)
 

--- a/go-packages/meep-rnis-client/api/swagger.yaml
+++ b/go-packages/meep-rnis-client/api/swagger.yaml
@@ -201,7 +201,7 @@ paths:
       - name: "app_ins_id"
         in: "query"
         description: "Application instance identifier"
-        required: true
+        required: false
         type: "array"
         items:
           type: "string"
@@ -4047,7 +4047,7 @@ parameters:
     name: "app_ins_id"
     in: "query"
     description: "Application instance identifier"
-    required: true
+    required: false
     type: "array"
     items:
       type: "string"

--- a/go-packages/meep-rnis-client/api_default.go
+++ b/go-packages/meep-rnis-client/api_default.go
@@ -2373,11 +2373,17 @@ func (a *DefaultApiService) MeasTaSubscriptionsSubscrIdDELETE(ctx context.Contex
 DefaultApiService
 Gets the information on Mobile Network(s) that are associated with a specific mobile edge application instance
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param appInsId Application instance identifier
+ * @param optional nil or *PlmnInfoGETOpts - Optional Parameters:
+     * @param "AppInsId" (optional.Interface of []string) -  Application instance identifier
 
 @return InlineResponse2001
 */
-func (a *DefaultApiService) PlmnInfoGET(ctx context.Context, appInsId []string) (InlineResponse2001, *http.Response, error) {
+
+type PlmnInfoGETOpts struct {
+	AppInsId optional.Interface
+}
+
+func (a *DefaultApiService) PlmnInfoGET(ctx context.Context, localVarOptionals *PlmnInfoGETOpts) (InlineResponse2001, *http.Response, error) {
 	var (
 		localVarHttpMethod  = strings.ToUpper("Get")
 		localVarPostBody    interface{}
@@ -2393,7 +2399,9 @@ func (a *DefaultApiService) PlmnInfoGET(ctx context.Context, appInsId []string) 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("app_ins_id", parameterToString(appInsId, "csv"))
+	if localVarOptionals != nil && localVarOptionals.AppInsId.IsSet() {
+		localVarQueryParams.Add("app_ins_id", parameterToString(localVarOptionals.AppInsId.Value(), "csv"))
+	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}
 

--- a/go-packages/meep-rnis-client/docs/DefaultApi.md
+++ b/go-packages/meep-rnis-client/docs/DefaultApi.md
@@ -503,7 +503,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **PlmnInfoGET**
-> InlineResponse2001 PlmnInfoGET(ctx, appInsId)
+> InlineResponse2001 PlmnInfoGET(ctx, optional)
 
 
 Gets the information on Mobile Network(s) that are associated with a specific mobile edge application instance
@@ -513,7 +513,14 @@ Gets the information on Mobile Network(s) that are associated with a specific mo
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-  **appInsId** | [**[]string**](string.md)| Application instance identifier | 
+ **optional** | ***PlmnInfoGETOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a pointer to a PlmnInfoGETOpts struct
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **appInsId** | [**optional.Interface of []string**](string.md)| Application instance identifier | 
 
 ### Return type
 

--- a/go-packages/meep-wais-notification-client/api/swagger.yaml
+++ b/go-packages/meep-wais-notification-client/api/swagger.yaml
@@ -157,7 +157,7 @@ definitions:
           seconds: 1577836800
           nanoSeconds: 0
         apId:
-          macId: "11:22:33:44:55:66"
+          macId: "AA2233445566"
   ApIdentity:
     type: "object"
     required:
@@ -165,7 +165,7 @@ definitions:
     properties:
       macId:
         type: "string"
-        example: "11:22:33:44:55:66"
+        example: "AA2233445566"
         description: "Identifier assigned to an Access Point for communications at\
           \ the data link layer of a network segment."
       ssid:
@@ -183,7 +183,7 @@ definitions:
     properties:
       macId:
         type: "string"
-        example: "11:22:33:44:55:66"
+        example: "AA2233445566"
         description: "Identifier assigned to station for communications at the data\
           \ link layer of a network segment."
       ssid:

--- a/go-packages/meep-wais-notification-client/api/swagger.yaml
+++ b/go-packages/meep-wais-notification-client/api/swagger.yaml
@@ -158,8 +158,6 @@ definitions:
           nanoSeconds: 0
         apId:
           macId: "11:22:33:44:55:66"
-          ssid: "mySsid"
-          ipAddress: "1.2.3.4"
   ApIdentity:
     type: "object"
     required:


### PR DESCRIPTION
Few fixes included in this PR:

Location service
- Location service does not report WIFI number of users correctly [loc-serv-sbi.go update]

WAI service [all fix in wais.go]
- Remove timestamp from Sta Info
- Missing return data: ApLocation and BssLoad
- Remove RSSI from Sta Info

RNI service
- PLMN Info should return a PLMN even if no appId provided in the query [biggest fix in there]
- RAB Release not issued when going out of a 4G POA element toward a 5G POA element [rnis.go line 272]
