### PR TITLE
Configurable Maximum Session Count

### DIFF
--- a/charts/meep-platform-ctrl/templates/deployment.yaml
+++ b/charts/meep-platform-ctrl/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           env:
             {{- range $key, $value := .Values.image.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
             {{- if .Values.user.frontend.enabled}}
             - name: USER_FRONTEND

--- a/charts/meep-platform-ctrl/values.yaml
+++ b/charts/meep-platform-ctrl/values.yaml
@@ -25,6 +25,7 @@ image:
   pullPolicy: Always
   env:
     MEEP_SESSION_KEY: "my-secret-key"
+    MEEP_MAX_SESSIONS: "10"
 
 service:
   type: ClusterIP

--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -598,6 +598,36 @@ services:
 #       mode: 'allow'
 
 #   #------------------------------
+#   #  WAI Service
+#   #------------------------------
+#   meep-wais:
+#     # REST API endpoint routes: names provided to endpoint routes during router initialization
+#     Index:
+#       # access authorization mode: allow|block|verify
+#       mode: 'block'
+#     ApInfoGET:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     StaInfoGET:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     SubscriptionLinkListSubscriptionsGET:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     SubscriptionsGET:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     SubscriptionsPOST:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     SubscriptionsPUT:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+#     SubscriptionsSubscrIdDELETE:
+#       # access authorization mode: allow|block|verify
+#       mode: 'allow'
+
+#   #------------------------------
 #   #  Sandbox Controller
 #   #------------------------------
 #   meep-sandbox-ctrl:

--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -144,6 +144,7 @@ func Init() (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB, location service table")
 
 	// Connect to Session Manager

--- a/go-apps/meep-platform-ctrl/server/platform-ctrl.go
+++ b/go-apps/meep-platform-ctrl/server/platform-ctrl.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -51,6 +53,7 @@ type PlatformCtrl struct {
 	sandboxStore  *ss.SandboxStore
 	userStore     *users.Connector
 	mqGlobal      *mq.MsgQueue
+	maxSessions   int
 }
 
 const scenarioDBName = "scenarios"
@@ -81,6 +84,12 @@ func Init() (err error) {
 
 	// Create new Platform Controller
 	pfmCtrl = new(PlatformCtrl)
+
+	// Retrieve maximum session count from environment variable
+	if maxSessions, err := strconv.ParseInt(os.Getenv("MEEP_MAX_SESSIONS"), 10, 0); err == nil {
+		pfmCtrl.maxSessions = int(maxSessions)
+	}
+	log.Info("MEEP_MAX_SESSIONS: ", pfmCtrl.maxSessions)
 
 	// Create message queue
 	pfmCtrl.mqGlobal, err = mq.NewMsgQueue(mq.GetGlobalName(), moduleName, moduleNamespace, redisDBAddr)

--- a/go-apps/meep-platform-ctrl/server/user_authentication.go
+++ b/go-apps/meep-platform-ctrl/server/user_authentication.go
@@ -59,7 +59,7 @@ func uaLoginUser(w http.ResponseWriter, r *http.Request) {
 		if count >= pfmCtrl.maxSessions {
 			err = errors.New("Maximum session count exceeded")
 			log.Error(err.Error())
-			http.Error(w, err.Error(), http.StatusInsufficientStorage)
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 			return
 		}
 

--- a/go-apps/meep-platform-ctrl/server/user_authentication.go
+++ b/go-apps/meep-platform-ctrl/server/user_authentication.go
@@ -54,6 +54,15 @@ func uaLoginUser(w http.ResponseWriter, r *http.Request) {
 	sessionStore := pfmCtrl.sessionMgr.GetSessionStore()
 	session, err := sessionStore.GetByName(username)
 	if err != nil {
+		// Check if max session count is reached before creating a new one
+		count := sessionStore.GetCount()
+		if count >= pfmCtrl.maxSessions {
+			err = errors.New("Maximum session count exceeded")
+			log.Error(err.Error())
+			http.Error(w, err.Error(), http.StatusInsufficientStorage)
+			return
+		}
+
 		// Get requested sandbox name from user profile, if any
 		user, err := pfmCtrl.userStore.GetUser(username)
 		if err == nil {

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -138,6 +138,7 @@ func Init() (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB, RNI service table")
 
 	// Connect to Session Manager

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -122,6 +122,7 @@ func Init() (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB, RNI service table")
 
 	// Connect to Session Manager

--- a/go-packages/meep-sessions/session-store.go
+++ b/go-packages/meep-sessions/session-store.go
@@ -137,6 +137,18 @@ func (ss *SessionStore) Get(r *http.Request) (s *Session, err error) {
 	return s, nil
 }
 
+// GetCount - Retrieve session count
+func (ss *SessionStore) GetCount() (count int) {
+	_ = ss.rc.ForEachEntry(ss.baseKey+"*", getCountHandler, &count)
+	return count
+}
+
+func getCountHandler(key string, fields map[string]string, userData interface{}) error {
+	count := userData.(*int)
+	*count += 1
+	return nil
+}
+
 // GetAll - Retrieve session by name
 func (ss *SessionStore) GetAll() (sessionList []*Session, err error) {
 	// Get all sessions, if any


### PR DESCRIPTION
**CHANGES:**
- Platform Controller:
  - MEEP_MAX_SESSIONS environment variable to configure max simultaneous session count
- Session Store:
  - New method to retrieve current session count
- loc-serv, rnis, wais:
  - Flush scenario data on service startup
- permissions.yaml
  - Sample endpoint permissions for WAIS

**TESTING:**
- Cypress & UT pass
- Manual verification of max session count