### PR TITLE
UT failure for location service and WAIS

### DIFF
--- a/go-apps/meep-loc-serv/server/loc-serv_test.go
+++ b/go-apps/meep-loc-serv/server/loc-serv_test.go
@@ -1667,8 +1667,8 @@ func TestAPInfo(t *testing.T) {
 	/******************************
 	 * expected response section
 	 ******************************/
-	expectedConnType := CONTYPE_UNKNOWN
-	expectedOpStatus := OPSTATUS_UNKNOWN
+	expectedConnType := MACRO
+	expectedOpStatus := SERVICEABLE
 	expectedTimeZone := time.Time{}
 	expectedAPInfo := AccessPointInfo{"zone1-poa-cell1", nil, &expectedConnType, &expectedOpStatus, 2, expectedTimeZone, "", ""}
 

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -235,7 +235,9 @@ func isUpdateApInfoNeeded(jsonApInfoComplete string, newLong int32, newLat int32
 	var oldLat int32 = 0
 	var oldLong int32 = 0
 
-	if jsonApInfoComplete != "" {
+	if jsonApInfoComplete == "" {
+		return true
+	} else {
 		apInfoComplete := convertJsonToApInfoComplete(jsonApInfoComplete)
 		oldStaMacIds = apInfoComplete.StaMacIds
 
@@ -257,7 +259,6 @@ func isUpdateApInfoNeeded(jsonApInfoComplete string, newLong int32, newLat int32
 
 	//if the list of connected STAs is different
 	return !reflect.DeepEqual(oldStaMacIds, staMacIds)
-
 }
 
 func updateApInfo(name string, apMacId string, longitude *float32, latitude *float32, staMacIds []string) {


### PR DESCRIPTION
Location services:
fixes UT expected result to match new implementation

WAIS:
UT revealed an issue when starting a DB from scratch. Redis DB was not populated unless an apLocation was configured. If no apLocation were configured, AP would not be created by the sbi. If apLocation is configured, values of longitude and latitude are non zero, so was triggering the update. Now fixed to force the update when not already in the DB.

Testing
UT passed