### PR TITLE
Meepctl Helm fix + Version bump to 1.5.4

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 1.5.3
+version: 1.5.4
 repo:
   name: AdvantEDGE
 

--- a/go-apps/meepctl/cmd/version.go
+++ b/go-apps/meepctl/cmd/version.go
@@ -41,7 +41,7 @@ type versionInfo struct {
 	BuildID   string `json:"build,omitempty"`
 }
 
-const meepctlVersion = "1.5.3"
+const meepctlVersion = "1.5.4"
 const na = "NA"
 
 const versionDesc = `Display version information

--- a/go-apps/meepctl/utils/config.go
+++ b/go-apps/meepctl/utils/config.go
@@ -31,7 +31,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const configVersion = "1.5.3"
+const configVersion = "1.5.4"
 
 const defaultNotSet = "not set"
 

--- a/go-apps/meepctl/utils/helm.go
+++ b/go-apps/meepctl/utils/helm.go
@@ -37,7 +37,7 @@ func IsHelmRelease(name string, cobraCmd *cobra.Command) (exist bool, err error)
 	if verbose {
 		fmt.Println("Cmd:", cmd.Args)
 	}
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	elapsed := time.Since(start)
 	if err != nil {
 		err = errors.New("Error listing component [" + name + "]")
@@ -45,7 +45,6 @@ func IsHelmRelease(name string, cobraCmd *cobra.Command) (exist bool, err error)
 	} else {
 		s := string(out)
 		exist = strings.HasPrefix(s, name)
-
 	}
 	if verbose {
 		r := FormatResult("Result: "+string(out), elapsed, cobraCmd)

--- a/go-packages/meep-model/validator.go
+++ b/go-packages/meep-model/validator.go
@@ -34,7 +34,7 @@ const (
 )
 
 // Current validator version
-var ValidatorVersion = semver.Version{Major: 1, Minor: 5, Patch: 3}
+var ValidatorVersion = semver.Version{Major: 1, Minor: 5, Patch: 4}
 
 // Versions requiring scenario update
 var Version130 = semver.Version{Major: 1, Minor: 3, Patch: 0}


### PR DESCRIPTION
**CHANGES:**
- Bumped version to 1.5.4 to force a meepctl update
  - Required for helm v3 update
- Fixed helm output parsing error due to possible "Warning" output with helm v3.3+

**TESTING:**
- Cypress & UT pass