### PR TITLE
Configurable GitHub & GitLab OAuth providers + Session Metrics

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 1.5.9
+version: 1.5.10
 repo:
   name: AdvantEDGE
 
@@ -33,7 +33,7 @@ repo:
       # host name
       host: my-platform-fqdn
       # enable https only (redirect http requests to https port)
-      https-only: true
+      https-only: false
       # bind to host ports (true) or node ports (false)
       host-ports: true
       # http port number
@@ -47,15 +47,37 @@ repo:
 
     # authentication & authorization config
     auth:
-      # session encryption key k8s secret (data: encryption-key)
-      session-key-secret: meep-session
-      # Github OAuth k8s secret (data: client-id, secret)
-      github-secret: meep-oauth-github
-      # Github OAuth k8s secret (data: client-id, secret)
-      gitlab-secret: meep-oauth-gitlab
-      # OAuth redirect URI
-      redirect-uri: https://my-platform-fqdn/platform-ctrl/v1/authorize
-
+      session:
+        # session encryption key k8s secret (data: encryption-key)
+        key-secret: meep-session
+        # maximum simultaneous sessions
+        max-sessions: 10
+      # GitHub OAuth provider config
+      github:
+        # enable GitHub OAuth
+        enabled: true
+        # authorization url
+        auth-url: https://github.com/login/oauth/authorize
+        # access token url
+        token-url: https://github.com/login/oauth/access_token
+        # OAuth redirect URI
+        redirect-uri: https://my-platform-fqdn/platform-ctrl/v1/authorize
+        # OAuth k8s secret (data: client-id, secret)
+        secret: meep-oauth-github
+      # GitLab OAuth provider config
+      gitlab:
+        # enable GitLab OAuth
+        enabled: true
+        # authorization url
+        auth-url: https://gitlab.com/oauth/authorize
+        # access token url
+        token-url: https://gitlab.com/oauth/token
+        # OAuth redirect URI
+        redirect-uri: https://my-platform-fqdn/platform-ctrl/v1/authorize
+        # GitLab api url
+        # api-url: https://gitlab.com
+        # OAuth k8s secret (data: client-id, secret)
+        secret: meep-oauth-gitlab
 
   #------------------------------
   #  Core Subsystem

--- a/charts/meep-platform-ctrl/values.yaml
+++ b/charts/meep-platform-ctrl/values.yaml
@@ -25,7 +25,15 @@ image:
   pullPolicy: Always
   env:
     MEEP_MAX_SESSIONS: "10"
-    MEEP_OAUTH_REDIRECT_URI: "https://<my-platform-fqdn>/platform-ctrl/v1/authorize"
+    MEEP_OAUTH_GITHUB_ENABLED: "false"
+    MEEP_OAUTH_GITHUB_AUTH_URL: ""
+    MEEP_OAUTH_GITHUB_TOKEN_URL: ""
+    MEEP_OAUTH_GITHUB_REDIRECT_URI: ""
+    MEEP_OAUTH_GITLAB_ENABLED: "false"
+    MEEP_OAUTH_GITLAB_AUTH_URL: ""
+    MEEP_OAUTH_GITLAB_TOKEN_URL: ""
+    MEEP_OAUTH_GITLAB_REDIRECT_URI: ""
+    MEEP_OAUTH_GITLAB_API_URL: ""
   envSecret:
     MEEP_SESSION_KEY:
       name: meep-session

--- a/go-apps/meep-platform-ctrl/go.mod
+++ b/go-apps/meep-platform-ctrl/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-model v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger v0.0.0
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-metric-store v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-model v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis v0.0.0
@@ -28,6 +29,7 @@ replace (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-key-mgr => ../../go-packages/meep-data-key-mgr
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-data-model => ../../go-packages/meep-data-model
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger => ../../go-packages/meep-logger
+	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-metric-store => ../../go-packages/meep-metric-store
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-model => ../../go-packages/meep-model
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq => ../../go-packages/meep-mq
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis => ../../go-packages/meep-redis

--- a/go-apps/meep-platform-ctrl/go.sum
+++ b/go-apps/meep-platform-ctrl/go.sum
@@ -141,6 +141,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e h1:txQltCyjXAqVVSZDArPEhUTg35hKwVIuXwtQo7eAMNQ=
+github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go-apps/meep-platform-ctrl/server/user_authentication.go
+++ b/go-apps/meep-platform-ctrl/server/user_authentication.go
@@ -85,12 +85,18 @@ func initOAuth() {
 	gitlabClientId := strings.TrimSpace(os.Getenv("MEEP_OAUTH_GITLAB_CLIENT_ID"))
 	gitlabSecret := strings.TrimSpace(os.Getenv("MEEP_OAUTH_GITLAB_SECRET"))
 	if gitlabClientId != "" && gitlabSecret != "" {
+		// var etsiGitlabEndpoint = oauth2.Endpoint{
+		// 	AuthURL:  "https://forge.etsi.org/rep/oauth/authorize",
+		// 	TokenURL: "https://forge.etsi.org/rep/oauth/token",
+		// }
+
 		gitlabOauthConfig := &oauth2.Config{
 			ClientID:     gitlabClientId,
 			ClientSecret: gitlabSecret,
 			RedirectURL:  redirectUri,
 			Scopes:       []string{"read_user"},
 			Endpoint:     gitlaboauth.Endpoint,
+			// Endpoint:     etsiGitlabEndpoint,
 		}
 		pfmCtrl.oauthConfigs[OAUTH_PROVIDER_GITLAB] = gitlabOauthConfig
 	}
@@ -261,6 +267,7 @@ func uaAuthorize(w http.ResponseWriter, r *http.Request) {
 		userId = *user.Login
 	case OAUTH_PROVIDER_GITLAB:
 		client, err := gitlab.NewOAuthClient(token.AccessToken)
+		// client, err := gitlab.NewOAuthClient(token.AccessToken, gitlab.WithBaseURL("https://forge.etsi.org/rep/api/v4"))
 		if err != nil {
 			err = errors.New("Failed to create new GitLab client")
 			log.Error(err.Error())

--- a/go-apps/meepctl/cmd/version.go
+++ b/go-apps/meepctl/cmd/version.go
@@ -41,7 +41,7 @@ type versionInfo struct {
 	BuildID   string `json:"build,omitempty"`
 }
 
-const meepctlVersion = "1.5.9"
+const meepctlVersion = "1.5.10"
 const na = "NA"
 
 const versionDesc = `Display version information

--- a/go-apps/meepctl/utils/config.go
+++ b/go-apps/meepctl/utils/config.go
@@ -31,7 +31,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const configVersion = "1.5.9"
+const configVersion = "1.5.10"
 
 const defaultNotSet = "not set"
 

--- a/go-packages/meep-metric-store/events_test.go
+++ b/go-packages/meep-metric-store/events_test.go
@@ -26,7 +26,7 @@ import (
 const eventStoreName string = "event-store"
 const eventStoreNamespace string = "event-ns"
 const eventStoreInfluxAddr string = "http://localhost:30986"
-const eventStoreRedisAddr string = "localhost:30380"
+const eventStoreRedisAddr string = MetricsDbDisabled
 
 func TestEventsMetricsGetSet(t *testing.T) {
 	fmt.Println("--- ", t.Name())

--- a/go-packages/meep-metric-store/metric-store.go
+++ b/go-packages/meep-metric-store/metric-store.go
@@ -35,6 +35,7 @@ import (
 const defaultInfluxDBAddr = "http://meep-influxdb.default.svc.cluster.local:8086"
 const dbMaxRetryCount = 2
 
+const MetricsDbDisabled = "disabled"
 const metricsDb = 0
 const metricsKey = "metric-store:"
 
@@ -50,7 +51,6 @@ type MetricStore struct {
 	namespace      string
 	baseKey        string
 	addr           string
-	connected      bool
 	influxClient   *influx.Client
 	redisClient    *redis.Connector
 	snapshotTicker *time.Ticker
@@ -70,24 +70,28 @@ func NewMetricStore(name string, namespace string, influxAddr string, redisAddr 
 	ms.baseKey = dkm.GetKeyRoot(namespace) + metricsKey
 
 	// Connect to Redis DB
-	ms.redisClient, err = redis.NewConnector(redisAddr, metricsDb)
-	if err != nil {
-		log.Error("Failed connection to Metrics redis DB. Error: ", err)
-		return nil, err
+	if redisAddr != MetricsDbDisabled {
+		ms.redisClient, err = redis.NewConnector(redisAddr, metricsDb)
+		if err != nil {
+			log.Error("Failed connection to Metrics redis DB. Error: ", err)
+			return nil, err
+		}
+		log.Info("Connected to Metrics Redis DB")
 	}
-	log.Info("Connected to Metrics Redis DB")
 
 	// Connect to Influx DB
-	for retry := 0; !ms.connected && retry <= dbMaxRetryCount; retry++ {
-		err = ms.connectInfluxDB(influxAddr)
-		if err != nil {
-			log.Warn("Failed to connect to InfluxDB. Retrying... Error: ", err)
+	if influxAddr != MetricsDbDisabled {
+		for retry := 0; ms.influxClient == nil && retry <= dbMaxRetryCount; retry++ {
+			err = ms.connectInfluxDB(influxAddr)
+			if err != nil {
+				log.Warn("Failed to connect to InfluxDB. Retrying... Error: ", err)
+			}
 		}
+		if err != nil {
+			return nil, err
+		}
+		log.Info("Connected to Metrics Influx DB")
 	}
-	if err != nil {
-		return nil, err
-	}
-	log.Info("Connected to Metrics Influx DB")
 
 	// Set store to use
 	err = ms.SetStore(name)
@@ -96,7 +100,7 @@ func NewMetricStore(name string, namespace string, influxAddr string, redisAddr 
 		return nil, err
 	}
 
-	log.Info("Successfully connected to Influx DB")
+	log.Info("Successfully create Metric Store")
 	return ms, nil
 }
 
@@ -122,7 +126,6 @@ func (ms *MetricStore) connectInfluxDB(addr string) error {
 	}
 
 	ms.influxClient = &client
-	ms.connected = true
 	log.Info("InfluxDB Connector connected to ", ms.addr, " version: ", version)
 	return nil
 }
@@ -137,15 +140,18 @@ func (ms *MetricStore) SetStore(name string) error {
 		storeName = strings.Replace(ms.namespace+"_"+name, "-", "_", -1)
 
 		// Create new DB if necessary
-		q := influx.NewQuery("CREATE DATABASE "+storeName, "", "")
-		_, err := (*ms.influxClient).Query(q)
-		if err != nil {
-			log.Error("Query failed with error: ", err.Error())
-			return err
+		if ms.influxClient != nil {
+			q := influx.NewQuery("CREATE DATABASE "+storeName, "", "")
+			_, err := (*ms.influxClient).Query(q)
+			if err != nil {
+				log.Error("Query failed with error: ", err.Error())
+				return err
+			}
 		}
 	}
 
 	// Update store name
+	log.Info("Store name set to: ", storeName)
 	ms.name = storeName
 	return nil
 }
@@ -158,15 +164,19 @@ func (ms *MetricStore) Flush() {
 	}
 
 	// Flush Influx DB
-	q := influx.NewQuery("DROP SERIES FROM /.*/", ms.name, "")
-	response, err := (*ms.influxClient).Query(q)
-	if err != nil {
-		log.Error("Query failed with error: ", err.Error())
+	if ms.influxClient != nil {
+		q := influx.NewQuery("DROP SERIES FROM /.*/", ms.name, "")
+		response, err := (*ms.influxClient).Query(q)
+		if err != nil {
+			log.Error("Query failed with error: ", err.Error())
+		}
+		log.Info(response.Results)
 	}
-	log.Info(response.Results)
 
 	// Flush Redis DB
-	ms.redisClient.DBFlush(ms.baseKey + NetMetName)
+	if ms.redisClient != nil {
+		ms.redisClient.DBFlush(ms.baseKey + NetMetName)
+	}
 }
 
 // Copy
@@ -174,6 +184,11 @@ func (ms *MetricStore) Copy(src string, dst string) error {
 	// Validate input params
 	if src == "" || dst == "" {
 		err := errors.New("Invalid params: " + src + ", " + dst)
+		log.Error("Error: ", err.Error())
+		return err
+	}
+	if ms.influxClient == nil {
+		err := errors.New("Not connected to Influx DB")
 		log.Error("Error: ", err.Error())
 		return err
 	}
@@ -215,6 +230,9 @@ func (ms *MetricStore) SetInfluxMetric(metricList []Metric) error {
 	if ms.name == "" {
 		return errors.New("Store name not specified")
 	}
+	if ms.influxClient == nil {
+		return errors.New("Not connected to Influx DB")
+	}
 
 	// Create a new point batch
 	bp, _ := influx.NewBatchPoints(influx.BatchPointsConfig{
@@ -246,6 +264,9 @@ func (ms *MetricStore) GetInfluxMetric(metric string, tags map[string]string, fi
 	// Make sure we have set a store
 	if ms.name == "" {
 		return values, errors.New("Store name not specified")
+	}
+	if ms.influxClient == nil {
+		return values, errors.New("Not connected to Influx DB")
 	}
 
 	// Create query
@@ -328,6 +349,10 @@ func (ms *MetricStore) SetRedisMetric(metric string, tagStr string, fields map[s
 		err = errors.New("Store name not specified")
 		return
 	}
+	if ms.redisClient == nil {
+		err = errors.New("Redis metrics DB disabled")
+		return
+	}
 
 	// Store data
 	key := ms.baseKey + metric + ":" + tagStr
@@ -345,6 +370,10 @@ func (ms *MetricStore) GetRedisMetric(metric string, tagStr string) (values []ma
 	// Make sure we have set a store
 	if ms.name == "" {
 		err := errors.New("Store name not specified")
+		return values, err
+	}
+	if ms.redisClient == nil {
+		err = errors.New("Redis metrics DB disabled")
 		return values, err
 	}
 

--- a/go-packages/meep-metric-store/session.go
+++ b/go-packages/meep-metric-store/session.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2019  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metricstore
+
+import (
+	"errors"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+const SesMetName = "session"
+const SesMetProvider = "provider"
+const SesMetUser = "user"
+const SesMetType = "type"
+const SesMetSid = "sid"
+const SesMetSbox = "sbox"
+const SesMetErrType = "errtype"
+const SesMetDesc = "desc"
+
+// Session metric types
+const (
+	SesMetTypeLogin  = "login"
+	SesMetTypeLogout = "logout"
+	SesMetTypeError  = "error"
+)
+
+// Session metric error types
+const (
+	SesMetErrTypeOauth       = "oauth"
+	SesMetErrTypeMaxSessions = "maxsessions"
+)
+
+type SessionMetric struct {
+	Time        interface{}
+	Provider    string
+	User        string
+	SessionId   string
+	Sandbox     string
+	ErrType     string
+	Description string
+}
+
+// SetSessionMetric
+func (ms *MetricStore) SetSessionMetric(typ string, sm SessionMetric) error {
+	metricList := make([]Metric, 1)
+	metric := &metricList[0]
+	metric.Name = SesMetName
+	metric.Tags = map[string]string{SesMetType: typ}
+	metric.Fields = map[string]interface{}{
+		SesMetProvider: sm.Provider,
+		SesMetUser:     sm.User,
+		SesMetSid:      sm.SessionId,
+		SesMetSbox:     sm.Sandbox,
+		SesMetErrType:  sm.ErrType,
+		SesMetDesc:     sm.Description,
+	}
+	return ms.SetInfluxMetric(metricList)
+}
+
+// GetSessionMetric
+func (ms *MetricStore) GetSessionMetric(typ string, duration string, count int) (metrics []SessionMetric, err error) {
+	// Make sure we have set a store
+	if ms.name == "" {
+		err = errors.New("Store name not specified")
+		return
+	}
+
+	// Get Session metrics
+	tags := map[string]string{}
+	if typ != "" {
+		tags[SesMetType] = typ
+	}
+	fields := []string{SesMetProvider, SesMetUser, SesMetSid, SesMetSbox, SesMetErrType, SesMetDesc}
+	var valuesArray []map[string]interface{}
+	valuesArray, err = ms.GetInfluxMetric(SesMetName, tags, fields, duration, count)
+	if err != nil {
+		log.Error("Failed to retrieve metrics with error: ", err.Error())
+		return
+	}
+
+	// Format event metrics
+	metrics = make([]SessionMetric, len(valuesArray))
+	for index, values := range valuesArray {
+		metrics[index].Time = values[NetMetTime]
+		if val, ok := values[SesMetProvider].(string); ok {
+			metrics[index].Provider = val
+		}
+		if val, ok := values[SesMetUser].(string); ok {
+			metrics[index].User = val
+		}
+		if val, ok := values[SesMetSid].(string); ok {
+			metrics[index].SessionId = val
+		}
+		if val, ok := values[SesMetSbox].(string); ok {
+			metrics[index].Sandbox = val
+		}
+		if val, ok := values[SesMetErrType].(string); ok {
+			metrics[index].ErrType = val
+		}
+		if val, ok := values[SesMetDesc].(string); ok {
+			metrics[index].Description = val
+		}
+	}
+	return
+}

--- a/go-packages/meep-metric-store/session.go
+++ b/go-packages/meep-metric-store/session.go
@@ -24,12 +24,12 @@ import (
 
 const SesMetName = "session"
 const SesMetProvider = "provider"
-const SesMetUser = "user"
+const SesMetUser = "userid"
 const SesMetType = "type"
 const SesMetSid = "sid"
 const SesMetSbox = "sbox"
 const SesMetErrType = "errtype"
-const SesMetDesc = "desc"
+const SesMetDesc = "description"
 
 // Session metric types
 const (
@@ -91,7 +91,6 @@ func (ms *MetricStore) GetSessionMetric(typ string, duration string, count int) 
 		log.Error("Failed to retrieve metrics with error: ", err.Error())
 		return
 	}
-
 	// Format event metrics
 	metrics = make([]SessionMetric, len(valuesArray))
 	for index, values := range valuesArray {

--- a/go-packages/meep-metric-store/session.go
+++ b/go-packages/meep-metric-store/session.go
@@ -33,9 +33,10 @@ const SesMetDesc = "description"
 
 // Session metric types
 const (
-	SesMetTypeLogin  = "login"
-	SesMetTypeLogout = "logout"
-	SesMetTypeError  = "error"
+	SesMetTypeLogin   = "login"
+	SesMetTypeLogout  = "logout"
+	SesMetTypeTimeout = "timeout"
+	SesMetTypeError   = "error"
 )
 
 // Session metric error types

--- a/go-packages/meep-metric-store/session_test.go
+++ b/go-packages/meep-metric-store/session_test.go
@@ -76,37 +76,37 @@ func TestSessionMetricsGetSet(t *testing.T) {
 	if err != nil || len(sml) != 1 {
 		t.Fatalf("Failed to get metric")
 	}
-	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+	if !validateSessionMetric(sml[0], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
 		t.Fatalf("Invalid event metric")
 	}
 	sml, err = ms.GetSessionMetric(SesMetTypeLogin, "", 0)
 	if err != nil || len(sml) != 2 {
 		t.Fatalf("Failed to get metric")
 	}
-	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+	if !validateSessionMetric(sml[0], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
 		t.Fatalf("Invalid event metric")
 	}
-	if !validateSessionMetric(sml[1], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
+	if !validateSessionMetric(sml[1], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
 		t.Fatalf("Invalid event metric")
 	}
 	sml, err = ms.GetSessionMetric(SesMetTypeLogout, "", 0)
 	if err != nil || len(sml) != 2 {
 		t.Fatalf("Failed to get metric")
 	}
-	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+	if !validateSessionMetric(sml[0], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
 		t.Fatalf("Invalid event metric")
 	}
-	if !validateSessionMetric(sml[1], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
+	if !validateSessionMetric(sml[1], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
 		t.Fatalf("Invalid event metric")
 	}
 	sml, err = ms.GetSessionMetric(SesMetTypeError, "", 0)
 	if err != nil || len(sml) != 2 {
 		t.Fatalf("Failed to get metric")
 	}
-	if !validateSessionMetric(sml[0], "provider2", "2.2.2.2", "", "", SesMetErrTypeOauth, "session2 error description") {
+	if !validateSessionMetric(sml[0], "provider3", "3.3.3.3", "", "", SesMetErrTypeMaxSessions, "session3 error description") {
 		t.Fatalf("Invalid event metric")
 	}
-	if !validateSessionMetric(sml[1], "provider3", "3.3.3.3", "", "", SesMetErrTypeMaxSessions, "session3 error description") {
+	if !validateSessionMetric(sml[1], "provider2", "2.2.2.2", "", "", SesMetErrTypeOauth, "session2 error description") {
 		t.Fatalf("Invalid event metric")
 	}
 

--- a/go-packages/meep-metric-store/session_test.go
+++ b/go-packages/meep-metric-store/session_test.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metricstore
+
+import (
+	"fmt"
+	"testing"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+const sessionStoreName string = "session-store"
+const sessionStoreNamespace string = "common"
+const sessionStoreInfluxAddr string = "http://localhost:30986"
+const sessionStoreRedisAddr string = MetricsDbDisabled
+
+func TestSessionMetricsGetSet(t *testing.T) {
+	fmt.Println("--- ", t.Name())
+	log.MeepTextLogInit(t.Name())
+
+	fmt.Println("Create valid Metric Store")
+	ms, err := NewMetricStore(sessionStoreName, sessionStoreNamespace, sessionStoreInfluxAddr, sessionStoreRedisAddr)
+	if err != nil {
+		t.Fatalf("Unable to create Metric Store")
+	}
+
+	fmt.Println("Flush store metrics")
+	ms.Flush()
+
+	fmt.Println("Set session metric")
+	err = ms.SetSessionMetric(SesMetTypeLogin, SessionMetric{nil, "provider1", "user1", "sid1", "sbox1", "", "session1 description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+	err = ms.SetSessionMetric(SesMetTypeLogout, SessionMetric{nil, "provider1", "user1", "sid1", "sbox1", "", "session1 description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+	err = ms.SetSessionMetric(SesMetTypeError, SessionMetric{nil, "provider2", "2.2.2.2", "", "", SesMetErrTypeOauth, "session2 error description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+	err = ms.SetSessionMetric(SesMetTypeError, SessionMetric{nil, "provider3", "3.3.3.3", "", "", SesMetErrTypeMaxSessions, "session3 error description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+	err = ms.SetSessionMetric(SesMetTypeLogin, SessionMetric{nil, "provider4", "user4", "sid4", "sbox4", "", "session4 description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+	err = ms.SetSessionMetric(SesMetTypeLogout, SessionMetric{nil, "provider4", "user4", "sid4", "sbox4", "", "session4 description"})
+	if err != nil {
+		t.Fatalf("Unable to set session metric")
+	}
+
+	fmt.Println("Get session metrics")
+	sml, err := ms.GetSessionMetric(SesMetTypeLogin, "1ms", 0)
+	if err != nil || len(sml) != 0 {
+		t.Fatalf("No metrics should be found in the last 1 ms")
+	}
+	sml, err = ms.GetSessionMetric(SesMetTypeLogin, "", 1)
+	if err != nil || len(sml) != 1 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+		t.Fatalf("Invalid event metric")
+	}
+	sml, err = ms.GetSessionMetric(SesMetTypeLogin, "", 0)
+	if err != nil || len(sml) != 2 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+		t.Fatalf("Invalid event metric")
+	}
+	if !validateSessionMetric(sml[1], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
+		t.Fatalf("Invalid event metric")
+	}
+	sml, err = ms.GetSessionMetric(SesMetTypeLogout, "", 0)
+	if err != nil || len(sml) != 2 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSessionMetric(sml[0], "provider1", "user1", "sid1", "sbox1", "", "session1 description") {
+		t.Fatalf("Invalid event metric")
+	}
+	if !validateSessionMetric(sml[1], "provider4", "user4", "sid4", "sbox4", "", "session4 description") {
+		t.Fatalf("Invalid event metric")
+	}
+	sml, err = ms.GetSessionMetric(SesMetTypeError, "", 0)
+	if err != nil || len(sml) != 2 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSessionMetric(sml[0], "provider2", "2.2.2.2", "", "", SesMetErrTypeOauth, "session2 error description") {
+		t.Fatalf("Invalid event metric")
+	}
+	if !validateSessionMetric(sml[1], "provider3", "3.3.3.3", "", "", SesMetErrTypeMaxSessions, "session3 error description") {
+		t.Fatalf("Invalid event metric")
+	}
+
+	// t.Fatalf("DONE")
+}
+
+func validateSessionMetric(sm SessionMetric, provider string, user string, sid string, sbox string, errType string, description string) bool {
+	if sm.Provider != provider {
+		fmt.Println("sm.Provider[" + sm.Provider + "] != provider [" + provider + "]")
+		return false
+	}
+	if sm.User != user {
+		fmt.Println("sm.User[" + sm.User + "] != user [" + user + "]")
+		return false
+	}
+	if sm.SessionId != sid {
+		fmt.Println("sm.SessionId[" + sm.SessionId + "] != sid [" + sid + "]")
+		return false
+	}
+	if sm.Sandbox != sbox {
+		fmt.Println("sm.Sandbox[" + sm.Sandbox + "] != sbox [" + sbox + "]")
+		return false
+	}
+	if sm.ErrType != errType {
+		fmt.Println("sm.ErrType[" + sm.ErrType + "] != errType [" + errType + "]")
+		return false
+	}
+	if sm.Description != description {
+		fmt.Println("sm.Description[" + sm.Description + "] != description [" + description + "]")
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
**CHANGES:**
- Deployment configuration:
  - Bumped version to 1.5.10
  - Added config points to enable/disable github & gitlab oauth providers
- charts:
  - Added environment variables to platform controller chart to configure oauth providers
- meepctl:
  - Configure platform controller environment variables according to deployment config
- Platform Controller:
  - Support for configurable oauth provider info
  - New dependency on metric store to log session metrics (login, logout, timeout, errors)
- Metric Store:
  - Ability to initialize metric store instance for influx only (e.g. session & event logging), redis only (e.g. TC sidecar network metrics), or both (e.g. network metrics with snapshot thread runnning)
  - New Session Metrics to log key sessions events & data in influxdb

**TESTING:**
- Cypress & UT pass
- Manual verification of configurable OAuth providers
- Manual verification of session metrics