### PR TITLE
Removed sandbox name from release name

### DIFF
--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -610,7 +610,7 @@ func addExpectedPods(sandboxName string) {
 		// Get sandbox-specific pod name
 		var podName string
 		prefix := "meep-"
-		sandboxPrefix := prefix + sandboxName + "-"
+		sandboxPrefix := prefix
 		if strings.HasPrefix(pod, prefix) {
 			podName = sandboxPrefix + pod[len(prefix):]
 		} else {
@@ -632,7 +632,7 @@ func removeExpectedPods(sandboxName string) {
 		// Get sandbox-specific pod name
 		var podName string
 		prefix := "meep-"
-		sandboxPrefix := prefix + sandboxName + "-"
+		sandboxPrefix := prefix
 		if strings.HasPrefix(pod, prefix) {
 			podName = sandboxPrefix + pod[len(prefix):]
 		} else {

--- a/go-apps/meep-mon-engine/server/mon-engine.go
+++ b/go-apps/meep-mon-engine/server/mon-engine.go
@@ -474,9 +474,9 @@ func meGetStates(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if querySandbox != "" || querySandbox == "all" {
-			for k, v := range expectedSboxPods {
+			for _, v := range expectedSboxPods {
 				if v.Sandbox == querySandbox || querySandbox == "all" {
-					data.ExpectedPods[k] = v
+					data.ExpectedPods[v.Name] = v
 				}
 			}
 		}
@@ -608,13 +608,15 @@ func getPodName(app string, name string) string {
 func addExpectedPods(sandboxName string) {
 	for _, pod := range sboxPodsList {
 		// Get sandbox-specific pod name
-		var podName string
+		var podName, podKeyName string
 		prefix := "meep-"
-		sandboxPrefix := prefix
+		sandboxPrefix := prefix + sandboxName + "-"
 		if strings.HasPrefix(pod, prefix) {
-			podName = sandboxPrefix + pod[len(prefix):]
+			podName = pod
+			podKeyName = sandboxPrefix + pod[len(prefix):]
 		} else {
-			podName = sandboxPrefix + pod
+			podName = prefix + pod
+			podKeyName = sandboxPrefix + pod
 		}
 
 		// Add to expected sandbox pods list
@@ -623,7 +625,7 @@ func addExpectedPods(sandboxName string) {
 		podStatus.Sandbox = sandboxName
 		podStatus.Name = podName
 		podStatus.LogicalState = "NotAvailable"
-		expectedSboxPods[podName] = podStatus
+		expectedSboxPods[podKeyName] = podStatus
 	}
 }
 
@@ -632,7 +634,7 @@ func removeExpectedPods(sandboxName string) {
 		// Get sandbox-specific pod name
 		var podName string
 		prefix := "meep-"
-		sandboxPrefix := prefix
+		sandboxPrefix := prefix + sandboxName + "-"
 		if strings.HasPrefix(pod, prefix) {
 			podName = sandboxPrefix + pod[len(prefix):]
 		} else {

--- a/go-apps/meep-virt-engine/helm/helm.go
+++ b/go-apps/meep-virt-engine/helm/helm.go
@@ -16,8 +16,8 @@
 
 package helm
 
-func GetReleasesName() ([]Release, error) {
-	return getReleasesName()
+func GetReleasesName(sandboxName string) ([]Release, error) {
+	return getReleasesName(sandboxName)
 }
 
 /*
@@ -25,14 +25,14 @@ func GetReleasesName() ([]Release, error) {
 * https://github.com/helm/helm/issues/5952
  */
 
-func GetReleases() ([]Release, error) {
-	return getReleases()
+func GetReleases(sandboxName string) ([]Release, error) {
+	return getReleases(sandboxName)
 }
 
-func InstallCharts(charts []Chart) error {
-	return runTask(Install, charts)
+func InstallCharts(charts []Chart, sandboxName string) error {
+	return runTask(Install, charts, sandboxName)
 }
 
-func DeleteReleases(charts []Chart) error {
-	return runTask(Delete, charts)
+func DeleteReleases(charts []Chart, sandboxName string) error {
+	return runTask(Delete, charts, sandboxName)
 }

--- a/go-apps/meep-virt-engine/helm/install.go
+++ b/go-apps/meep-virt-engine/helm/install.go
@@ -24,8 +24,8 @@ import (
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
-func installCharts(charts []Chart) error {
-	err := ensureReleases(charts)
+func installCharts(charts []Chart, sandboxName string) error {
+	err := ensureReleases(charts, sandboxName)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func installCharts(charts []Chart) error {
 		err := install(chart)
 		if err != nil {
 			log.Info("Cleaning installed releases")
-			cleanReleases(charts)
+			cleanReleases(charts, sandboxName)
 			return err
 		}
 	}
@@ -42,9 +42,9 @@ func installCharts(charts []Chart) error {
 	return nil
 }
 
-func ensureReleases(charts []Chart) error {
+func ensureReleases(charts []Chart, sandboxName string) error {
 	// ensure that releases do not already exist
-	releases, _ := GetReleasesName()
+	releases, _ := GetReleasesName(sandboxName)
 	for _, c := range charts {
 		for _, r := range releases {
 			if c.ReleaseName == r.Name {
@@ -83,10 +83,10 @@ func install(chart Chart) error {
 	return nil
 }
 
-func cleanReleases(charts []Chart) {
+func cleanReleases(charts []Chart, sandboxName string) {
 	var toClean []Chart
 	var cnt int
-	releases, _ := GetReleasesName()
+	releases, _ := GetReleasesName(sandboxName)
 
 	for _, c := range charts {
 		for _, r := range releases {

--- a/go-apps/meep-virt-engine/helm/list.go
+++ b/go-apps/meep-virt-engine/helm/list.go
@@ -31,7 +31,7 @@ func getReleasesName(sandboxName string) ([]Release, error) {
 		return nil, err
 	}
 
-	release, err := parseList(out, true)
+	release, err := parseList(out, true, sandboxName)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func getReleases(sandboxName string) ([]Release, error) {
 		return nil, err
 	}
 
-	release, err := parseList(out, false)
+	release, err := parseList(out, false, sandboxName)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func getList(sandboxName string) ([]byte, error) {
 	return out, nil
 }
 
-func parseList(buf []byte, nameOnly bool) ([]Release, error) {
+func parseList(buf []byte, nameOnly bool, sandboxName string) ([]Release, error) {
 	/* Example of what needs to be parsed
 	NAME    REVISION        UPDATED                         STATUS          CHART                   NAMESPACE
 	osvc1   1               Tue Jun 12 13:02:55 2018        DEPLOYED        orientation-svc-0.1.0   default
@@ -87,7 +87,7 @@ func parseList(buf []byte, nameOnly bool) ([]Release, error) {
 		r.Name = scanWords.Text()
 		if !nameOnly {
 			// Status
-			sp, err := GetReleaseStatus(r.Name)
+			sp, err := GetReleaseStatus(r.Name, sandboxName)
 			r.Status = *sp
 			if err != nil {
 				log.Error(err)

--- a/go-apps/meep-virt-engine/helm/list.go
+++ b/go-apps/meep-virt-engine/helm/list.go
@@ -25,8 +25,8 @@ import (
 	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
 )
 
-func getReleasesName() ([]Release, error) {
-	out, err := getList()
+func getReleasesName(sandboxName string) ([]Release, error) {
+	out, err := getList(sandboxName)
 	if err != nil {
 		return nil, err
 	}
@@ -38,8 +38,8 @@ func getReleasesName() ([]Release, error) {
 	return release, nil
 }
 
-func getReleases() ([]Release, error) {
-	out, err := getList()
+func getReleases(sandboxName string) ([]Release, error) {
+	out, err := getList(sandboxName)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +51,8 @@ func getReleases() ([]Release, error) {
 	return release, nil
 }
 
-func getList() ([]byte, error) {
-	var cmd = exec.Command("helm", "ls", "-A")
+func getList(sandboxName string) ([]byte, error) {
+	var cmd = exec.Command("helm", "ls", "-n", sandboxName)
 	out, err := cmd.Output()
 	if err != nil {
 		err = errors.New("Unable to list Releases")

--- a/go-apps/meep-virt-engine/helm/status.go
+++ b/go-apps/meep-virt-engine/helm/status.go
@@ -30,8 +30,8 @@ const STATUS string = "STATUS:"
 const RESOURCE string = "==>"
 
 // Returns the status of a release
-func GetReleaseStatus(name string) (*Status, error) {
-	out, err := getStatus(name)
+func GetReleaseStatus(name string, sandboxName string) (*Status, error) {
+	out, err := getStatus(name, sandboxName)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +43,8 @@ func GetReleaseStatus(name string) (*Status, error) {
 	return status, nil
 }
 
-func getStatus(name string) ([]byte, error) {
-	var cmd = exec.Command("helm", "status", name)
+func getStatus(name string, sandboxName string) ([]byte, error) {
+	var cmd = exec.Command("helm", "status", "-n", sandboxName, name)
 	out, err := cmd.Output()
 	if err != nil {
 		err = errors.New("Error getting status for Release [" + name + "]")

--- a/go-apps/meep-virt-engine/helm/worker.go
+++ b/go-apps/meep-virt-engine/helm/worker.go
@@ -28,8 +28,9 @@ const (
 )
 
 type Job struct {
-	task   Task
-	charts []Chart
+	task        Task
+	charts      []Chart
+	sandboxName string
 }
 
 var queue *chan Job = nil
@@ -46,7 +47,7 @@ func startWorker() {
 			switch job.task {
 			case Install:
 				log.Debug("Installing ", len(job.charts), " Charts...")
-				_ = installCharts(job.charts)
+				_ = installCharts(job.charts, job.sandboxName)
 				log.Debug("Charts installed (", len(job.charts), ")")
 
 			case Delete:
@@ -59,9 +60,9 @@ func startWorker() {
 	}()
 }
 
-func runTask(task Task, charts []Chart) error {
+func runTask(task Task, charts []Chart, sandboxName string) error {
 	startWorker()
-	var job Job = Job{task: task, charts: charts}
+	var job Job = Job{task: task, charts: charts, sandboxName: sandboxName}
 	*queue <- job
 	return nil
 }

--- a/go-apps/meep-virt-engine/server/chart-template.go
+++ b/go-apps/meep-virt-engine/server/chart-template.go
@@ -143,7 +143,7 @@ func Deploy(sandboxName string, model *mod.Model) error {
 	log.Debug("Created ", len(charts), " scenario charts")
 
 	// Deploy all charts
-	err = deployCharts(charts)
+	err = deployCharts(charts, sandboxName)
 	if err != nil {
 		log.Error("Error deploying charts: ", err)
 		return err
@@ -368,8 +368,8 @@ func generateScenarioCharts(sandboxName string, model *mod.Model) (charts []helm
 	return charts, nil
 }
 
-func deployCharts(charts []helm.Chart) error {
-	err := helm.InstallCharts(charts)
+func deployCharts(charts []helm.Chart, sandboxName string) error {
+	err := helm.InstallCharts(charts, sandboxName)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func newChart(chartName string, sandboxName string, scenarioName string, chartLo
 
 	// Create release name by adding sandbox + scenario prefix
 	prefix := "meep-"
-	sandboxPrefix := prefix + sandboxName + "-"
+	sandboxPrefix := prefix
 	if scenarioName == "" {
 		prefix := "meep-"
 		chart.ReleaseName = sandboxPrefix + chartName[len(prefix):]
@@ -585,7 +585,7 @@ func deploySandbox(name string) error {
 	log.Debug("Created ", len(charts), " sandbox charts")
 
 	// Deploy all charts
-	err = deployCharts(charts)
+	err = deployCharts(charts, name)
 	if err != nil {
 		log.Error("Error deploying charts: ", err)
 		return err

--- a/go-apps/meep-virt-engine/server/chart-template.go
+++ b/go-apps/meep-virt-engine/server/chart-template.go
@@ -429,14 +429,11 @@ func createChart(chartName string, sandboxName string, scenarioName string, temp
 func newChart(chartName string, sandboxName string, scenarioName string, chartLocation string, valuesFile string) helm.Chart {
 	var chart helm.Chart
 
-	// Create release name by adding sandbox + scenario prefix
-	prefix := "meep-"
-	sandboxPrefix := prefix
+	// Create release name by adding scenario prefix
 	if scenarioName == "" {
-		prefix := "meep-"
-		chart.ReleaseName = sandboxPrefix + chartName[len(prefix):]
+		chart.ReleaseName = chartName
 	} else {
-		chart.ReleaseName = sandboxPrefix + scenarioName + "-" + chartName
+		chart.ReleaseName = "meep-" + scenarioName + "-" + chartName
 	}
 
 	chart.Name = chartName

--- a/go-apps/meep-virt-engine/server/virt-engine.go
+++ b/go-apps/meep-virt-engine/server/virt-engine.go
@@ -298,7 +298,7 @@ func deleteReleases(sandboxName string, scenarioName string) (error, int) {
 
 	// Get chart prefix & path
 	path := "/charts/" + sandboxName
-	releasePrefix := "meep-" + sandboxName + "-"
+	releasePrefix := "meep-"
 	if scenarioName != "" {
 		path += "/scenario/"
 		releasePrefix += scenarioName + "-"
@@ -306,7 +306,7 @@ func deleteReleases(sandboxName string, scenarioName string) (error, int) {
 
 	// Retrieve list of releases
 	chartsToDelete := 0
-	rels, err := helm.GetReleasesName()
+	rels, err := helm.GetReleasesName(sandboxName)
 	if err == nil {
 		// Filter charts by sandbox & scenario names
 		var toDelete []helm.Chart
@@ -323,7 +323,7 @@ func deleteReleases(sandboxName string, scenarioName string) (error, int) {
 		chartsToDelete = len(toDelete)
 		if chartsToDelete > 0 {
 			log.Debug("Deleting [", chartsToDelete, "] charts with release prefix: ", releasePrefix)
-			err := helm.DeleteReleases(toDelete)
+			err := helm.DeleteReleases(toDelete, sandboxName)
 			chartsToDelete = len(toDelete)
 			if err != nil {
 				log.Debug("Releases deletion failure:", err)

--- a/go-apps/meep-webhook/webhook.go
+++ b/go-apps/meep-webhook/webhook.go
@@ -107,7 +107,7 @@ func loadConfig(configFile string) (*Config, error) {
 }
 
 // Determine if resource is part of the active scenario
-func isScenarioResource(name string, sandboxName string, scenarioName string) bool {
+func isScenarioResource(name string, scenarioName string) bool {
 	return name != "" && strings.HasPrefix(name, "meep-"+scenarioName+"-")
 }
 
@@ -278,7 +278,7 @@ func (whsvr *WebhookServer) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 	}
 
 	// Determine if resource is part of the active scenario
-	if !isScenarioResource(releaseName, req.Namespace, activeScenarioNames[req.Namespace]) {
+	if !isScenarioResource(releaseName, activeScenarioNames[req.Namespace]) {
 		log.Info("Resource not part of active scenario. Ignoring request...")
 		return &v1beta1.AdmissionResponse{
 			Allowed: true,

--- a/go-apps/meep-webhook/webhook.go
+++ b/go-apps/meep-webhook/webhook.go
@@ -108,7 +108,7 @@ func loadConfig(configFile string) (*Config, error) {
 
 // Determine if resource is part of the active scenario
 func isScenarioResource(name string, sandboxName string, scenarioName string) bool {
-	return name != "" && strings.HasPrefix(name, "meep-"+sandboxName+"-"+scenarioName+"-")
+	return name != "" && strings.HasPrefix(name, "meep-"+scenarioName+"-")
 }
 
 func getSidecarPatch(template corev1.PodTemplateSpec, sidecarConfig *Config, meepAppName string, sandboxName string) (patch []byte, err error) {


### PR DESCRIPTION
Changes:
- Removed sandbox name from Release names in mon-engine, virt-engine and webhook
- Helm list command only list pods in a namespace now instead of all

Test:
- Manually checked deploying and deleting demo1 in two separate sandboxes
- All UT's and Cypress test passed