### PR TITLE
location API resourceURL fix, WAIS Ap_info, Sta_info returning [], Edge node mobility support

### DIFF
--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -626,7 +626,7 @@ func usersGet(w http.ResponseWriter, r *http.Request) {
 	// Get user list from DB
 	var response InlineUserList
 	var userList UserList
-	userList.ResourceURL = hostUrl.String() + basePath + "users"
+	userList.ResourceURL = hostUrl.String() + basePath + "queries/users"
 	response.UserList = &userList
 	userData.userList = &userList
 
@@ -728,7 +728,7 @@ func apGet(w http.ResponseWriter, r *http.Request) {
 	var response InlineAccessPointList
 	var apList AccessPointList
 	apList.ZoneId = vars["zoneId"]
-	apList.ResourceURL = hostUrl.String() + basePath + "zones/" + vars["zoneId"] + "/accessPoints"
+	apList.ResourceURL = hostUrl.String() + basePath + "queries/zones/" + vars["zoneId"] + "/accessPoints"
 	response.AccessPointList = &apList
 	userData.apList = &apList
 
@@ -787,7 +787,7 @@ func zonesGet(w http.ResponseWriter, r *http.Request) {
 
 	var response InlineZoneList
 	var zoneList ZoneList
-	zoneList.ResourceURL = hostUrl.String() + basePath + "zones"
+	zoneList.ResourceURL = hostUrl.String() + basePath + "queries/zones"
 	response.ZoneList = &zoneList
 
 	keyName := baseKey + typeZone + ":*"
@@ -1523,7 +1523,7 @@ func updateUserInfo(address string, zoneId string, accessPointId string, longitu
 	if userInfo == nil {
 		userInfo = new(UserInfo)
 		userInfo.Address = address
-		userInfo.ResourceURL = hostUrl.String() + basePath + "users/" + address
+		userInfo.ResourceURL = hostUrl.String() + basePath + "queries/users?address=" + address
 	} else {
 		// Get old zone & AP IDs
 		oldZoneId = userInfo.ZoneId
@@ -1567,7 +1567,7 @@ func updateZoneInfo(zoneId string, nbAccessPoints int, nbUnsrvAccessPoints int, 
 	if zoneInfo == nil {
 		zoneInfo = new(ZoneInfo)
 		zoneInfo.ZoneId = zoneId
-		zoneInfo.ResourceURL = hostUrl.String() + basePath + "zones/" + zoneId
+		zoneInfo.ResourceURL = hostUrl.String() + basePath + "queries/zones/" + zoneId
 	}
 
 	// Update info
@@ -1595,7 +1595,7 @@ func updateAccessPointInfo(zoneId string, apId string, conTypeStr string, opStat
 	if apInfo == nil {
 		apInfo = new(AccessPointInfo)
 		apInfo.AccessPointId = apId
-		apInfo.ResourceURL = hostUrl.String() + basePath + "zones/" + zoneId + "/accessPoints/" + apId
+		apInfo.ResourceURL = hostUrl.String() + basePath + "queries/zones/" + zoneId + "/accessPoints/" + apId
 	}
 
 	// Update info

--- a/go-apps/meep-loc-serv/server/loc-serv_test.go
+++ b/go-apps/meep-loc-serv/server/loc-serv_test.go
@@ -1484,8 +1484,8 @@ func TestUserInfo(t *testing.T) {
 	/******************************
 	 * expected response section
 	 ******************************/
-	expectedListResourceURL := "/" + testScenarioName + "/location/v2/users"
-	expectedResourceURL := expectedListResourceURL + "/ue1"
+	expectedListResourceURL := "/" + testScenarioName + "/location/v2/queries/users"
+	expectedResourceURL := expectedListResourceURL + "?address=ue1"
 	//expectedListResourceURL := ""
 	//expectedResourceURL := ""
 	expectedUserInfo := UserInfo{"zone1-poa-cell1", "ue1", "", "", nil, expectedResourceURL, nil, "zone1"}
@@ -1537,7 +1537,7 @@ func testUserInfo(t *testing.T, userId string, expectedResponse string) {
 	 * request execution section
 	 ******************************/
 
-	rr, err := sendRequest(http.MethodGet, "/users", nil, nil, query, http.StatusOK, UsersGET)
+	rr, err := sendRequest(http.MethodGet, "/queries/users", nil, nil, query, http.StatusOK, UsersGET)
 	if err != nil {
 		t.Fatalf("Failed to get expected response")
 	}
@@ -1623,12 +1623,12 @@ func testZoneInfo(t *testing.T, zoneId string, expectedResponse string) {
 
 	var err error
 	if expectedResponse == "" {
-		_, err = sendRequest(http.MethodGet, "/zones", nil, vars, nil, http.StatusNotFound, ZonesGetById)
+		_, err = sendRequest(http.MethodGet, "/queries/zones", nil, vars, nil, http.StatusNotFound, ZonesGetById)
 		if err != nil {
 			t.Fatalf("Failed to get expected response")
 		}
 	} else {
-		rr, err := sendRequest(http.MethodGet, "/zones", nil, vars, nil, http.StatusOK, ZonesGetById)
+		rr, err := sendRequest(http.MethodGet, "/queries/zones", nil, vars, nil, http.StatusOK, ZonesGetById)
 		if err != nil {
 			t.Fatalf("Failed to get expected response")
 		}
@@ -1720,12 +1720,12 @@ func testAPInfo(t *testing.T, zoneId string, apId string, expectedResponse strin
 
 	var err error
 	if expectedResponse == "" {
-		_, err = sendRequest(http.MethodGet, "/zones/"+zoneId+"/accessPoints", nil, vars, nil, http.StatusNotFound, ApByIdGET)
+		_, err = sendRequest(http.MethodGet, "/queries/zones/"+zoneId+"/accessPoints", nil, vars, nil, http.StatusNotFound, ApByIdGET)
 		if err != nil {
 			t.Fatalf("Failed to get expected response")
 		}
 	} else {
-		rr, err := sendRequest(http.MethodGet, "/zones"+zoneId+"/accessPoints", nil, vars, nil, http.StatusOK, ApByIdGET)
+		rr, err := sendRequest(http.MethodGet, "/queries/zones"+zoneId+"/accessPoints", nil, vars, nil, http.StatusOK, ApByIdGET)
 		if err != nil {
 			t.Fatalf("Failed to get expected response")
 		}

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -770,6 +770,8 @@ func apInfoGET(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
 	var response ApInfoResp
+	//initialise array to make sure Marshal processes it properly if it is empty
+	response.ApInfoList = make([]ApInfo, 0)
 
 	//loop through each AP
 	keyName := baseKey + "AP:*"
@@ -787,6 +789,7 @@ func apInfoGET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+
 	fmt.Fprintf(w, string(jsonResponse))
 }
 
@@ -814,6 +817,8 @@ func populateStaInfo(key string, jsonInfo string, response interface{}) error {
 func staInfoGET(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	var response StaInfoResp
+	//initialise array to make sure Marshal processes it properly if it is empty
+	response.StaInfoList = make([]StaInfo, 0)
 
 	// Loop through each STA
 	keyName := baseKey + "UE:*"

--- a/go-packages/meep-model/model.go
+++ b/go-packages/meep-model/model.go
@@ -301,16 +301,25 @@ func (m *Model) MoveNode(nodeName string, destName string) (oldLocName string, n
 		return "", "", errors.New("Mobility: " + nodeName + " not found")
 	}
 
-	if moveNode.nodeType == "EDGE-APP" {
+	switch moveNode.nodeType {
+	case "EDGE-APP":
 		oldLocName, newLocName, err = m.moveProc(moveNode, destName)
 		if err != nil {
 			return "", "", err
 		}
-	} else {
+	case "FOG", "UE":
 		oldLocName, newLocName, err = m.movePL(moveNode, destName)
 		if err != nil {
 			return "", "", err
 		}
+	case "EDGE":
+		//edge nodes are children of default network locations
+		oldLocName, newLocName, err = m.movePL(moveNode, destName+"-DEFAULT")
+		if err != nil {
+			return "", "", err
+		}
+	default:
+		return "", "", errors.New("Unsupported nodeType " + moveNode.nodeType)
 	}
 
 	err = m.refresh()

--- a/go-packages/meep-model/model_test.go
+++ b/go-packages/meep-model/model_test.go
@@ -256,7 +256,17 @@ func TestMoveNode(t *testing.T) {
 	if new != "zone1-poa1" {
 		t.Fatalf("Move Node - wrong destination Location " + new)
 	}
-
+	fmt.Println("Move edge node zone1-edge1 to a new zone")
+	old, new, err = m.MoveNode("zone1-edge1", "zone2")
+	if err != nil {
+		t.Fatalf("Error moving EDGE node")
+	}
+	if old != "zone1-DEFAULT" {
+		t.Fatalf("Move Node - wrong origin Location " + old)
+	}
+	if new != "zone2-DEFAULT" {
+		t.Fatalf("Move Node - wrong destination Location " + new)
+	}
 	fmt.Println("Move zone1-edge1-iperf")
 	_, _, err = m.MoveNode("zone1-edge1-iperf", "zone2-edge2")
 	if err == nil {


### PR DESCRIPTION
Location API fix:
- resourceURL using queries as part of endpoints for users and zones 
- resourceURL for users using the query param also (was changed in v2 to be a query param)
- UT updated

WAIS:
Ap_Info and Sta_Info endpoints returning [] when empty array should be returned

Edge node mobility
- Model package updated to support edge node mobility
- UT updated

testing:
manual testing for all and ut passed