### PR TITLE
ZonalStatus fix, generic errors in mec services for missing mandatory properties, updated rnis rab_info query params

### DIFF
--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -990,17 +990,20 @@ func userTrackingSubPost(w http.ResponseWriter, r *http.Request) {
 	userTrackingSub := body.UserTrackingSubscription
 
 	if userTrackingSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if userTrackingSub.CallbackReference == nil || userTrackingSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if userTrackingSub.Address == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory Address parameter not present")
+		http.Error(w, "Mandatory Address parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1042,21 +1045,25 @@ func userTrackingSubPut(w http.ResponseWriter, r *http.Request) {
 	userTrackingSub := body.UserTrackingSubscription
 
 	if userTrackingSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if userTrackingSub.CallbackReference == nil || userTrackingSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if userTrackingSub.Address == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory Address parameter not present")
+		http.Error(w, "Mandatory Address parameter not present", http.StatusBadRequest)
 		return
 	}
 	if userTrackingSub.ResourceURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ResourceURL parameter not present")
+		http.Error(w, "Mandatory ResourceURL parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1067,7 +1074,8 @@ func userTrackingSubPut(w http.ResponseWriter, r *http.Request) {
 
 	//Body content not matching parameters
 	if subsIdStr != subsIdParamStr {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("SubscriptionId in endpoint and in body not matching")
+		http.Error(w, "SubscriptionId in endpoint and in body not matching", http.StatusBadRequest)
 		return
 	}
 
@@ -1202,17 +1210,20 @@ func zonalTrafficSubPost(w http.ResponseWriter, r *http.Request) {
 	zonalTrafficSub := body.ZonalTrafficSubscription
 
 	if zonalTrafficSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if zonalTrafficSub.CallbackReference == nil || zonalTrafficSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zonalTrafficSub.ZoneId == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ZoneId parameter not present")
+		http.Error(w, "Mandatory ZoneId parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1266,21 +1277,25 @@ func zonalTrafficSubPut(w http.ResponseWriter, r *http.Request) {
 	zonalTrafficSub := body.ZonalTrafficSubscription
 
 	if zonalTrafficSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if zonalTrafficSub.CallbackReference == nil || zonalTrafficSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zonalTrafficSub.ZoneId == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ZoneId parameter not present")
+		http.Error(w, "Mandatory ZoneId parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zonalTrafficSub.ResourceURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ResourceURL parameter not present")
+		http.Error(w, "Mandatory ResourceURL parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1291,7 +1306,8 @@ func zonalTrafficSubPut(w http.ResponseWriter, r *http.Request) {
 
 	//body content not matching parameters
 	if subsIdStr != subsIdParamStr {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("SubscriptionId in endpoint and in body not matching")
+		http.Error(w, "SubscriptionId in endpoint and in body not matching", http.StatusBadRequest)
 		return
 	}
 
@@ -1427,17 +1443,20 @@ func zoneStatusSubPost(w http.ResponseWriter, r *http.Request) {
 	zoneStatusSub := body.ZoneStatusSubscription
 
 	if zoneStatusSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if zoneStatusSub.CallbackReference == nil || zoneStatusSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zoneStatusSub.ZoneId == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ZoneId parameter not present")
+		http.Error(w, "Mandatory ZoneId parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1481,21 +1500,25 @@ func zoneStatusSubPut(w http.ResponseWriter, r *http.Request) {
 	zoneStatusSub := body.ZoneStatusSubscription
 
 	if zoneStatusSub == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Body not present")
+		http.Error(w, "Body not present", http.StatusBadRequest)
 		return
 	}
 
 	//checking for mandatory properties
 	if zoneStatusSub.CallbackReference == nil || zoneStatusSub.CallbackReference.NotifyURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zoneStatusSub.ZoneId == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ZoneId parameter not present")
+		http.Error(w, "Mandatory ZoneId parameter not present", http.StatusBadRequest)
 		return
 	}
 	if zoneStatusSub.ResourceURL == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("Mandatory ResourceURL parameter not present")
+		http.Error(w, "Mandatory ResourceURL parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1506,7 +1529,8 @@ func zoneStatusSubPut(w http.ResponseWriter, r *http.Request) {
 
 	//body content not matching parameters
 	if subsIdStr != subsIdParamStr {
-		w.WriteHeader(http.StatusBadRequest)
+		log.Error("SubscriptionId in endpoint and in body not matching")
+		http.Error(w, "SubscriptionId in endpoint and in body not matching", http.StatusBadRequest)
 		return
 	}
 

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -1100,6 +1100,13 @@ func subscriptionsPost(w http.ResponseWriter, r *http.Request) {
 	//extract common body part
 	subscriptionType := subscriptionCommon.SubscriptionType
 
+	//mandatory parameter
+	if subscriptionCommon.CallbackReference == "" {
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
+		return
+	}
+
 	//new subscription id
 	newSubsId := nextSubscriptionIdAvailable
 	nextSubscriptionIdAvailable++
@@ -1243,10 +1250,17 @@ func subscriptionsPut(w http.ResponseWriter, r *http.Request) {
 	//extract common body part
 	subscriptionType := subscriptionCommon.SubscriptionType
 
+	//mandatory parameter
+	if subscriptionCommon.CallbackReference == "" {
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
+		return
+	}
+
 	link := subscriptionCommon.Links
 	if link == nil || link.Self == nil {
-		w.WriteHeader(http.StatusBadRequest)
 		log.Error("Mandatory Link parameter not present")
+		http.Error(w, "Mandatory Link parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -1254,7 +1268,8 @@ func subscriptionsPut(w http.ResponseWriter, r *http.Request) {
 	subsIdStr := selfUrl[len(selfUrl)-1]
 
 	if subsIdStr != subIdParamStr {
-		http.Error(w, "Body content not matching parameter", http.StatusInternalServerError)
+		log.Error("SubscriptionId in endpoint and in body not matching")
+		http.Error(w, "SubscriptionId in endpoint and in body not matching", http.StatusBadRequest)
 		return
 	}
 
@@ -1273,7 +1288,7 @@ func subscriptionsPut(w http.ResponseWriter, r *http.Request) {
 
 		if subscription.FilterCriteriaAssocHo == nil {
 			log.Error("FilterCriteriaAssocHo should not be null for this subscription type")
-			http.Error(w, "FilterCriteriaAssocHo should not be null for this subscription type", http.StatusInternalServerError)
+			http.Error(w, "FilterCriteriaAssocHo should not be null for this subscription type", http.StatusBadRequest)
 			return
 		}
 
@@ -1299,7 +1314,7 @@ func subscriptionsPut(w http.ResponseWriter, r *http.Request) {
 
 		if subscription.FilterCriteriaQci == nil {
 			log.Error("FilterCriteriaQci should not be null for this subscription type")
-			http.Error(w, "FilterCriteriaQci should not be null for this subscription type", http.StatusInternalServerError)
+			http.Error(w, "FilterCriteriaQci should not be null for this subscription type", http.StatusBadRequest)
 			return
 		}
 
@@ -1321,7 +1336,7 @@ func subscriptionsPut(w http.ResponseWriter, r *http.Request) {
 
 		if subscription.FilterCriteriaQci == nil {
 			log.Error("FilterCriteriaQci should not be null for this subscription type")
-			http.Error(w, "FilterCriteriaQci should not be null for this subscription type", http.StatusInternalServerError)
+			http.Error(w, "FilterCriteriaQci should not be null for this subscription type", http.StatusBadRequest)
 			return
 		}
 

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -1667,13 +1667,16 @@ func TestSbi(t *testing.T) {
 		t.Fatalf("Error running test basic procedure")
 	}
 
+	ueName := "ue1"
+	appName := "zone1-edge1-iperf"
+
 	/******************************
 	 * expected values section
 	 ******************************/
 	var expectedUeDataStr [2]string
 	var expectedUeData [2]UeData
-	expectedUeData[INITIAL] = UeData{1, &Ecgi{"2345678", &Plmn{"123", "456"}}}
-	expectedUeData[UPDATED] = UeData{-1, &Ecgi{"", &Plmn{"123", "456"}}}
+	expectedUeData[INITIAL] = UeData{ueName, 1, &Ecgi{"2345678", &Plmn{"123", "456"}}, 80}
+	expectedUeData[UPDATED] = UeData{ueName, -1, &Ecgi{"", &Plmn{"123", "456"}}, 80}
 
 	var expectedAppEcgiStr [2]string
 	var expectedAppEcgi [2]Ecgi
@@ -1710,10 +1713,6 @@ func TestSbi(t *testing.T) {
 
 	fmt.Println("Set a scenario")
 	initialiseScenario(testScenario)
-
-	//different tests
-	ueName := "ue1"
-	appName := "zone1-edge1-iperf"
 
 	jsonEcgiInfo, _ := rc.JSONGetEntry(baseKey+"UE:"+ueName, ".")
 	if string(jsonEcgiInfo) != expectedUeDataStr[INITIAL] {

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -579,6 +579,13 @@ func subscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 	//extract common body part
 	subscriptionType := subscriptionCommon.SubscriptionType
 
+	//mandatory parameter
+	if subscriptionCommon.CallbackReference == "" {
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
+		return
+	}
+
 	//new subscription id
 	newSubsId := nextSubscriptionIdAvailable
 	nextSubscriptionIdAvailable++
@@ -640,10 +647,17 @@ func subscriptionsPUT(w http.ResponseWriter, r *http.Request) {
 	//extract common body part
 	subscriptionType := subscriptionCommon.SubscriptionType
 
+	//mandatory parameter
+	if subscriptionCommon.CallbackReference == "" {
+		log.Error("Mandatory CallbackReference parameter not present")
+		http.Error(w, "Mandatory CallbackReference parameter not present", http.StatusBadRequest)
+		return
+	}
+
 	link := subscriptionCommon.Links
 	if link == nil || link.Self == nil {
-		w.WriteHeader(http.StatusBadRequest)
 		log.Error("Mandatory Link parameter not present")
+		http.Error(w, "Mandatory Link parameter not present", http.StatusBadRequest)
 		return
 	}
 
@@ -651,7 +665,8 @@ func subscriptionsPUT(w http.ResponseWriter, r *http.Request) {
 	subsIdStr := selfUrl[len(selfUrl)-1]
 
 	if subsIdStr != subIdParamStr {
-		http.Error(w, "Body content not matching parameter", http.StatusInternalServerError)
+		log.Error("SubscriptionId in endpoint and in body not matching")
+		http.Error(w, "SubscriptionId in endpoint and in body not matching", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
1) ZonalStatus AP threshold fix (code was not hit)
2) Mandatory info in bodies checked for all location, RNI and WAI API subscription, if not there, returning BadRequest error.
3) RNIS GET rab_info supporting query parameters as per spec fix : qci, ipv4 address based on name as per current implementation, cellId being an array an not a comma separated string

ONLY #3 has impact on UT, ut updated and passed
no impact on cypress.