### PR TITLE
Updated helm charts Incubator repository locations to new one

### DIFF
--- a/go-apps/meep-virt-engine/entrypoint.sh
+++ b/go-apps/meep-virt-engine/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configure & update helm repo
-helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+helm repo add incubator https://charts.helm.sh/incubator
 helm repo update
 
 # Start virt engine

--- a/playbooks/roles/helm/tasks/install.yml
+++ b/playbooks/roles/helm/tasks/install.yml
@@ -8,10 +8,9 @@
     state: present
 
 - name: "Enable incubator charts"
-  shell: "helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/ --kubeconfig .kube/config"
+  shell: "helm repo add incubator https://charts.helm.sh/incubator --kubeconfig .kube/config"
   tags: helm
 
 - name: "Repo Update"
   shell: "helm repo update --kubeconfig .kube/config"
   tags: helm
-


### PR DESCRIPTION
Changes:
Updated helm charts Incubator repository locations to https://charts.helm.sh/incubator from https://kubernetes-charts-incubator.storage.googleapis.com according to helm release documents https://helm.sh/blog/new-location-stable-incubator-charts/