### PR TITLE
Scenario Name check in platform API

### DIFF
--- a/go-apps/meep-platform-ctrl/server/platform-ctrl.go
+++ b/go-apps/meep-platform-ctrl/server/platform-ctrl.go
@@ -126,7 +126,7 @@ func Init() (err error) {
 
 	// Validate DB scenarios & upgrade them if compatible
 	for _, scenario := range scenarioList {
-		validScenario, status, err := mod.ValidateScenario(scenario)
+		validScenario, status, err := mod.ValidateScenario(scenario, "")
 		if err == nil && status == mod.ValidatorStatusUpdated {
 			// Retrieve scenario name
 			s := new(Scenario)
@@ -202,7 +202,7 @@ func pcCreateScenario(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate scenario
-	validScenario, _, err := mod.ValidateScenario(b)
+	validScenario, _, err := mod.ValidateScenario(b, scenarioName)
 	if err != nil {
 		log.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -352,7 +352,7 @@ func pcSetScenario(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate scenario
-	validScenario, _, err := mod.ValidateScenario(b)
+	validScenario, _, err := mod.ValidateScenario(b, scenarioName)
 	if err != nil {
 		log.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/go-packages/meep-model/validator.go
+++ b/go-packages/meep-model/validator.go
@@ -59,7 +59,7 @@ func createNetChar(lat int32, latVar int32, dist string, tputDl int32, tputUl in
 }
 
 // ValidateScenario - Verify if json scenario is valid & supported. Upgrade scenario if possible & necessary.
-func ValidateScenario(jsonScenario []byte) (validJsonScenario []byte, status string, err error) {
+func ValidateScenario(jsonScenario []byte, name string) (validJsonScenario []byte, status string, err error) {
 	var scenarioVersion semver.Version
 	var scenarioUpdated = false
 
@@ -70,6 +70,14 @@ func ValidateScenario(jsonScenario []byte) (validJsonScenario []byte, status str
 		log.Error(err.Error())
 		return nil, ValidatorStatusError, err
 	}
+
+	if name != "" {
+		if scenario.Name != name {
+                        err = errors.New("Scenario creation name " + name + " incompatible with scenario body content name " + scenario.Name + ". They must be the same.")
+                        return nil, ValidatorStatusError, err
+		}
+	}
+
 	// Retrieve scenario version
 	// If no version found, assume & set current validator version
 	if scenario.Version == "" {


### PR DESCRIPTION
Scenario name MUST be identical both in the endpoint and in the body content otherwise an error is sent.

Otherwise, creating multiple entries (based on the endpoint name) that points to the same scenario name is possible.