### PR TITLE
L2Meas endpoint implementation

### DIFF
--- a/go-apps/meep-auth-svc/go.mod
+++ b/go-apps/meep-auth-svc/go.mod
@@ -18,10 +18,12 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.7.4
 	github.com/lkysow/go-gitlab v0.7.1
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/prometheus/client_golang v1.9.0
 	github.com/roymx/viper v1.3.3-0.20190416163942-b9a223fc58a3
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
 replace (

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -326,7 +326,20 @@ func processActiveScenarioUpdate() {
 						throughputUL = ue.NetChar.ThroughputUl
 					}
 
-					sbi.updateUeDataCB(UeDataSbi{name, mnc, mcc, cellId, nrcellId, erabIdValid, appNames, latency, throughputUL, throughputDL, ploss})
+					var ueDataSbi = UeDataSbi{
+						Name:         name,
+						Mnc:          mnc,
+						Mcc:          mcc,
+						CellId:       cellId,
+						NrCellId:     nrcellId,
+						ErabIdValid:  erabIdValid,
+						AppNames:     appNames,
+						Latency:      latency,
+						ThroughputUL: throughputUL,
+						ThroughputDL: throughputDL,
+						PacketLoss:   ploss,
+					}
+					sbi.updateUeDataCB(ueDataSbi)
 				}
 			}
 		}
@@ -342,7 +355,12 @@ func processActiveScenarioUpdate() {
 			}
 		}
 		if !found {
-			sbi.updateUeDataCB(UeDataSbi{prevUeName, "", "", "", "", false, nil, 0, 0, 0, 0.0})
+			var ueDataSbi = UeDataSbi{
+				Name:        prevUeName,
+				ErabIdValid: false,
+			}
+
+			sbi.updateUeDataCB(ueDataSbi)
 			log.Info("Ue removed : ", prevUeName)
 		}
 	}
@@ -374,7 +392,16 @@ func processActiveScenarioUpdate() {
 				throughputUL = pl.NetChar.ThroughputUl
 			}
 
-			sbi.updateAppInfoCB(AppInfoSbi{appName, pl.Type_, pl.Name, latency, throughputUL, throughputDL, ploss})
+			var appInfoSbi = AppInfoSbi{
+				Name:         appName,
+				ParentType:   pl.Type_,
+				ParentName:   pl.Name,
+				Latency:      latency,
+				ThroughputUL: throughputUL,
+				ThroughputDL: throughputDL,
+				PacketLoss:   ploss,
+			}
+			sbi.updateAppInfoCB(appInfoSbi)
 		}
 	}
 
@@ -388,7 +415,11 @@ func processActiveScenarioUpdate() {
 			}
 		}
 		if !found {
-			sbi.updateAppInfoCB(AppInfoSbi{prevApp, "", "", 0, 0, 0, 0.0})
+			var appInfoSbi = AppInfoSbi{
+				Name: prevApp,
+			}
+
+			sbi.updateAppInfoCB(appInfoSbi)
 			log.Info("App removed : ", prevApp)
 		}
 	}
@@ -434,7 +465,18 @@ func processActiveScenarioUpdate() {
 					throughputUL = nl.NetChar.ThroughputUl
 				}
 
-				sbi.updatePoaInfoCB(PoaInfoSbi{name, nl.Type_, mnc, mcc, cellId, latency, throughputUL, throughputDL, ploss})
+				var poaInfoSbi = PoaInfoSbi{
+					Name:         name,
+					PoaType:      nl.Type_,
+					Mnc:          mnc,
+					Mcc:          mcc,
+					CellId:       cellId,
+					Latency:      latency,
+					ThroughputUL: throughputUL,
+					ThroughputDL: throughputDL,
+					PacketLoss:   ploss,
+				}
+				sbi.updatePoaInfoCB(poaInfoSbi)
 			}
 		}
 	}

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -287,7 +287,7 @@ func processActiveScenarioUpdate() {
 						latency = ue.NetChar.Latency
 						ploss = ue.NetChar.PacketLoss
 						throughputDL = ue.NetChar.ThroughputDl
-                                                throughputUL = ue.NetChar.ThroughputUl
+						throughputUL = ue.NetChar.ThroughputUl
 					}
 
 					sbi.updateUeDataCB(name, mnc, mcc, cellId, nrcellId, erabIdValid, appNames, latency, throughputUL, throughputDL, ploss)
@@ -327,16 +327,16 @@ func processActiveScenarioUpdate() {
 				continue
 			}
 			appNames = append(appNames, appName)
-                        latency := int32(0)
-                        ploss := float64(0.0)
-                        throughputDL := int32(0)
-                        throughputUL := int32(0)
-                        if pl.NetChar != nil {
-	                        latency = pl.NetChar.Latency
-                                ploss = pl.NetChar.PacketLoss
-                                throughputDL = pl.NetChar.ThroughputDl
-                                throughputUL = pl.NetChar.ThroughputUl
-                        }
+			latency := int32(0)
+			ploss := float64(0.0)
+			throughputDL := int32(0)
+			throughputUL := int32(0)
+			if pl.NetChar != nil {
+				latency = pl.NetChar.Latency
+				ploss = pl.NetChar.PacketLoss
+				throughputDL = pl.NetChar.ThroughputDl
+				throughputUL = pl.NetChar.ThroughputUl
+			}
 
 			sbi.updateAppInfoCB(appName, pl.Type_, pl.Name, latency, throughputUL, throughputDL, ploss)
 		}
@@ -387,16 +387,16 @@ func processActiveScenarioUpdate() {
 					cellId = nl.Poa5GConfig.CellId
 				}
 
-                                latency := int32(0)
-                                ploss := float64(0.0)
-                                throughputDL := int32(0)
-                                throughputUL := int32(0)
-                                if nl.NetChar != nil {
-                                       latency = nl.NetChar.Latency
-                                       ploss = nl.NetChar.PacketLoss
-                                       throughputDL = nl.NetChar.ThroughputDl
-                                       throughputUL = nl.NetChar.ThroughputUl
-                                }
+				latency := int32(0)
+				ploss := float64(0.0)
+				throughputDL := int32(0)
+				throughputUL := int32(0)
+				if nl.NetChar != nil {
+					latency = nl.NetChar.Latency
+					ploss = nl.NetChar.PacketLoss
+					throughputDL = nl.NetChar.ThroughputDl
+					throughputUL = nl.NetChar.ThroughputUl
+				}
 
 				sbi.updatePoaInfoCB(name, nl.Type_, mnc, mcc, cellId, latency, throughputUL, throughputDL, ploss)
 			}

--- a/go-apps/meep-rnis/sbi/rnis-sbi.go
+++ b/go-apps/meep-rnis/sbi/rnis-sbi.go
@@ -28,13 +28,49 @@ import (
 
 const moduleName string = "meep-rnis-sbi"
 
+type UeDataSbi struct {
+	Name         string
+	Mnc          string
+	Mcc          string
+	CellId       string
+	NrCellId     string
+	ErabIdValid  bool
+	AppNames     []string
+	Latency      int32
+	ThroughputUL int32
+	ThroughputDL int32
+	PacketLoss   float64
+}
+
+type PoaInfoSbi struct {
+	Name         string
+	PoaType      string
+	Mnc          string
+	Mcc          string
+	CellId       string
+	Latency      int32
+	ThroughputUL int32
+	ThroughputDL int32
+	PacketLoss   float64
+}
+
+type AppInfoSbi struct {
+	Name         string
+	ParentType   string
+	ParentName   string
+	Latency      int32
+	ThroughputUL int32
+	ThroughputDL int32
+	PacketLoss   float64
+}
+
 type SbiCfg struct {
 	SandboxName    string
 	RedisAddr      string
-	UeDataCb       func(string, string, string, string, string, bool, []string, int32, int32, int32, float64)
+	UeDataCb       func(UeDataSbi)
 	MeasInfoCb     func(string, string, []string, []int32, []int32)
-	PoaInfoCb      func(string, string, string, string, string, int32, int32, int32, float64)
-	AppInfoCb      func(string, string, string, int32, int32, int32, float64)
+	PoaInfoCb      func(PoaInfoSbi)
+	AppInfoCb      func(AppInfoSbi)
 	DomainDataCb   func(string, string, string, string)
 	ScenarioNameCb func(string)
 	CleanUpCb      func()
@@ -47,10 +83,10 @@ type RnisSbi struct {
 	activeModel          *mod.Model
 	gisCache             *gc.GisCache
 	refreshTicker        *time.Ticker
-	updateUeDataCB       func(string, string, string, string, string, bool, []string, int32, int32, int32, float64)
+	updateUeDataCB       func(UeDataSbi)
 	updateMeasInfoCB     func(string, string, []string, []int32, []int32)
-	updatePoaInfoCB      func(string, string, string, string, string, int32, int32, int32, float64)
-	updateAppInfoCB      func(string, string, string, int32, int32, int32, float64)
+	updatePoaInfoCB      func(PoaInfoSbi)
+	updateAppInfoCB      func(AppInfoSbi)
 	updateDomainDataCB   func(string, string, string, string)
 	updateScenarioNameCB func(string)
 	cleanUpCB            func()
@@ -290,7 +326,7 @@ func processActiveScenarioUpdate() {
 						throughputUL = ue.NetChar.ThroughputUl
 					}
 
-					sbi.updateUeDataCB(name, mnc, mcc, cellId, nrcellId, erabIdValid, appNames, latency, throughputUL, throughputDL, ploss)
+					sbi.updateUeDataCB(UeDataSbi{name, mnc, mcc, cellId, nrcellId, erabIdValid, appNames, latency, throughputUL, throughputDL, ploss})
 				}
 			}
 		}
@@ -306,7 +342,7 @@ func processActiveScenarioUpdate() {
 			}
 		}
 		if !found {
-			sbi.updateUeDataCB(prevUeName, "", "", "", "", false, nil, 0, 0, 0, 0.0)
+			sbi.updateUeDataCB(UeDataSbi{prevUeName, "", "", "", "", false, nil, 0, 0, 0, 0.0})
 			log.Info("Ue removed : ", prevUeName)
 		}
 	}
@@ -338,7 +374,7 @@ func processActiveScenarioUpdate() {
 				throughputUL = pl.NetChar.ThroughputUl
 			}
 
-			sbi.updateAppInfoCB(appName, pl.Type_, pl.Name, latency, throughputUL, throughputDL, ploss)
+			sbi.updateAppInfoCB(AppInfoSbi{appName, pl.Type_, pl.Name, latency, throughputUL, throughputDL, ploss})
 		}
 	}
 
@@ -352,7 +388,7 @@ func processActiveScenarioUpdate() {
 			}
 		}
 		if !found {
-			sbi.updateAppInfoCB(prevApp, "", "", 0, 0, 0, 0.0)
+			sbi.updateAppInfoCB(AppInfoSbi{prevApp, "", "", 0, 0, 0, 0.0})
 			log.Info("App removed : ", prevApp)
 		}
 	}
@@ -398,7 +434,7 @@ func processActiveScenarioUpdate() {
 					throughputUL = nl.NetChar.ThroughputUl
 				}
 
-				sbi.updatePoaInfoCB(name, nl.Type_, mnc, mcc, cellId, latency, throughputUL, throughputDL, ploss)
+				sbi.updatePoaInfoCB(PoaInfoSbi{name, nl.Type_, mnc, mcc, cellId, latency, throughputUL, throughputDL, ploss})
 			}
 		}
 	}

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -3240,7 +3240,7 @@ func subscriptionLinkListSubscriptionsGet(w http.ResponseWriter, r *http.Request
 					break
 				}
 			}
-			if !found {
+			if found {
 				break
 			}
 		}

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -2180,15 +2180,19 @@ func TestSbi(t *testing.T) {
 	 ******************************/
 	var expectedUeDataStr [2]string
 	var expectedUeData [2]UeData
-	expectedAppNames := []string{"ue1-iperf"}
-	expectedUeData[INITIAL] = UeData{ueName, 1, &Ecgi{"2345678", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, poaName, nil, expectedAppNames}
-	expectedUeData[UPDATED] = UeData{ueName, -1, &Ecgi{"", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, poaNameAfter, nil, expectedAppNames}
 
-	var expectedAppInfoStr string
-	expectedAppInfo := AppInfo{"EDGE", "zone1-edge1"}
+	expectedUeData[INITIAL] = UeData{ueName, 1, &Ecgi{"2345678", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, "", nil, nil, 0, 1000, 1000, 0}
+	expectedUeData[UPDATED] = UeData{ueName, -1, &Ecgi{"", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, "", nil, nil, 0, 1000, 1000, 0}
 
-	var expectedPoaInfoStr string
-	expectedPoaInfo := PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}}
+	var expectedAppEcgiStr [2]string
+	var expectedAppEcgi [2]Ecgi
+	expectedAppEcgi[INITIAL] = Ecgi{"", &Plmn{"123", "456"}, 0, 1000, 1000, 0}
+	expectedAppEcgi[UPDATED] = Ecgi{"", &Plmn{"123", "456"}, 0, 1000, 1000, 0}
+
+	var expectedPoaInfoStr [2]string
+	var expectedPoaInfo [2]PoaInfo
+	expectedPoaInfo[INITIAL] = PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}, 0, 1000, 1000, 0}
+	expectedPoaInfo[UPDATED] = PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}, 0, 1000, 1000, 0}
 
 	j, err := json.Marshal(expectedUeData[INITIAL])
 	if err != nil {
@@ -2223,26 +2227,37 @@ func TestSbi(t *testing.T) {
 
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonInfo, _ := rc.JSONGetEntry(baseKey+"UE:"+ueName, ".")
-	if string(jsonInfo) != expectedUeDataStr[INITIAL] {
+	jsonEcgiInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	if string(jsonEcgiInfo) != expectedUeDataStr[INITIAL] {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonInfo, _ = rc.JSONGetEntry(baseKey+"APP:"+appName, ".")
-	if string(jsonInfo) != expectedAppInfoStr {
+	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
+	if string(jsonEcgiInfo) != expectedAppEcgiStr[INITIAL] {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonInfo, _ = rc.JSONGetEntry(baseKey+"POA:"+poaName, ".")
-	if string(jsonInfo) != expectedPoaInfoStr {
+	jsonPoaInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
+	if string(jsonPoaInfo) != expectedPoaInfoStr[INITIAL] {
 		t.Fatalf("Failed to get expected response")
 	}
 
 	updateScenario("mobility1")
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonInfo, _ = rc.JSONGetEntry(baseKey+"UE:"+ueName, ".")
-	if string(jsonInfo) != expectedUeDataStr[UPDATED] {
+	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	if string(jsonEcgiInfo) != expectedUeDataStr[UPDATED] {
+		fmt.Println("TEST FAILED but commented out, TODO")
+		//t.Fatalf("Failed to get expected response")
+	}
+
+	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
+	if string(jsonEcgiInfo) != expectedAppEcgiStr[UPDATED] {
+		t.Fatalf("Failed to get expected response")
+	}
+
+	jsonPoaInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
+	if string(jsonPoaInfo) != expectedPoaInfoStr[UPDATED] {
 		t.Fatalf("Failed to get expected response")
 	}
 

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -2181,18 +2181,15 @@ func TestSbi(t *testing.T) {
 	var expectedUeDataStr [2]string
 	var expectedUeData [2]UeData
 
-	expectedUeData[INITIAL] = UeData{ueName, 1, &Ecgi{"2345678", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, "", nil, nil, 0, 1000, 1000, 0}
-	expectedUeData[UPDATED] = UeData{ueName, -1, &Ecgi{"", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, "", nil, nil, 0, 1000, 1000, 0}
+	expectedAppNames := []string{"ue1-iperf"}
+	expectedUeData[INITIAL] = UeData{ueName, 1, &Ecgi{"2345678", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, poaName, nil, expectedAppNames, 0, 1000, 1000, 0.0}
+	expectedUeData[UPDATED] = UeData{ueName, -1, &Ecgi{"", &Plmn{"123", "456"}}, &NRcgi{"", &Plmn{"123", "456"}}, 80, poaNameAfter, nil, expectedAppNames, 0, 1000, 1000, 0.0}
 
-	var expectedAppEcgiStr [2]string
-	var expectedAppEcgi [2]Ecgi
-	expectedAppEcgi[INITIAL] = Ecgi{"", &Plmn{"123", "456"}, 0, 1000, 1000, 0}
-	expectedAppEcgi[UPDATED] = Ecgi{"", &Plmn{"123", "456"}, 0, 1000, 1000, 0}
+	var expectedAppInfoStr string
+	expectedAppInfo := AppInfo{"EDGE", "zone1-edge1", 0, 1000, 1000, 0}
 
-	var expectedPoaInfoStr [2]string
-	var expectedPoaInfo [2]PoaInfo
-	expectedPoaInfo[INITIAL] = PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}, 0, 1000, 1000, 0}
-	expectedPoaInfo[UPDATED] = PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}, 0, 1000, 1000, 0}
+	var expectedPoaInfoStr string
+	expectedPoaInfo := PoaInfo{"POA-4G", Ecgi{"2345678", &Plmn{"123", "456"}}, NRcgi{"", nil}, 1, 1000, 1000, 0}
 
 	j, err := json.Marshal(expectedUeData[INITIAL])
 	if err != nil {
@@ -2227,37 +2224,28 @@ func TestSbi(t *testing.T) {
 
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonEcgiInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
-	if string(jsonEcgiInfo) != expectedUeDataStr[INITIAL] {
+	jsonInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	if string(jsonInfo) != expectedUeDataStr[INITIAL] {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
-	if string(jsonEcgiInfo) != expectedAppEcgiStr[INITIAL] {
+	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
+	if string(jsonInfo) != expectedAppInfoStr {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonPoaInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
-	if string(jsonPoaInfo) != expectedPoaInfoStr[INITIAL] {
+	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
+	if string(jsonInfo) != expectedPoaInfoStr {
+		log.Info("SIMON  ", string(jsonInfo))
+		log.Info("SIMON2 ", expectedPoaInfoStr)
 		t.Fatalf("Failed to get expected response")
 	}
 
 	updateScenario("mobility1")
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
-	if string(jsonEcgiInfo) != expectedUeDataStr[UPDATED] {
-		fmt.Println("TEST FAILED but commented out, TODO")
-		//t.Fatalf("Failed to get expected response")
-	}
-
-	jsonEcgiInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
-	if string(jsonEcgiInfo) != expectedAppEcgiStr[UPDATED] {
-		t.Fatalf("Failed to get expected response")
-	}
-
-	jsonPoaInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
-	if string(jsonPoaInfo) != expectedPoaInfoStr[UPDATED] {
+	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	if string(jsonInfo) != expectedUeDataStr[UPDATED] {
 		t.Fatalf("Failed to get expected response")
 	}
 

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -2224,17 +2224,17 @@ func TestSbi(t *testing.T) {
 
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonInfo, _ := rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	jsonInfo, _ := rc.JSONGetEntry(baseKey+"UE:"+ueName, ".")
 	if string(jsonInfo) != expectedUeDataStr[INITIAL] {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"APP:"+appName, ".")
+	jsonInfo, _ = rc.JSONGetEntry(baseKey+"APP:"+appName, ".")
 	if string(jsonInfo) != expectedAppInfoStr {
 		t.Fatalf("Failed to get expected response")
 	}
 
-	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
+	jsonInfo, _ = rc.JSONGetEntry(baseKey+"POA:"+poaName, ".")
 	if string(jsonInfo) != expectedPoaInfoStr {
 		t.Fatalf("Failed to get expected response")
 	}
@@ -2242,7 +2242,7 @@ func TestSbi(t *testing.T) {
 	updateScenario("mobility1")
 	time.Sleep(1000 * time.Millisecond)
 
-	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"UE:"+ueName, ".")
+	jsonInfo, _ = rc.JSONGetEntry(baseKey+"UE:"+ueName, ".")
 	if string(jsonInfo) != expectedUeDataStr[UPDATED] {
 		t.Fatalf("Failed to get expected response")
 	}

--- a/go-apps/meep-rnis/server/rnis_test.go
+++ b/go-apps/meep-rnis/server/rnis_test.go
@@ -2236,8 +2236,6 @@ func TestSbi(t *testing.T) {
 
 	jsonInfo, _ = rc[RNIS_DB_CONNECTOR_INDEX].JSONGetEntry(baseKey+"POA:"+poaName, ".")
 	if string(jsonInfo) != expectedPoaInfoStr {
-		log.Info("SIMON  ", string(jsonInfo))
-		log.Info("SIMON2 ", expectedPoaInfoStr)
 		t.Fatalf("Failed to get expected response")
 	}
 

--- a/go-packages/meep-metric-store/network.go
+++ b/go-packages/meep-metric-store/network.go
@@ -79,6 +79,38 @@ func (ms *MetricStore) SetCachedNetworkMetric(metric NetworkMetric) (err error) 
 	return nil
 }
 
+// GetCachedNetworkMetrics
+func (ms *MetricStore) GetCachedNetworkMetrics(src string, dst string) (metric []NetworkMetric, err error) {
+        // Make sure we have set a store
+        if ms.name == "" {
+                err = errors.New("Store name not specified")
+                return
+        }
+
+        // Get current Network metric
+        tagStr := src + ":" + dst
+        var valuesArray []map[string]interface{}
+        valuesArray, err = ms.GetRedisMetric(NetMetName, tagStr)
+        if err != nil {
+                log.Error("Failed to retrieve metrics with error: ", err.Error())
+                return
+        }
+
+        metricList := make([]NetworkMetric, len(valuesArray))
+        for index, values := range valuesArray {
+                // Format network metric
+                nm, err := ms.formatCachedNetworkMetric(values)
+                if err != nil {
+                        continue
+                }
+                // Add metric to list
+                metricList[index] = nm
+        }
+
+        // Return formatted metric
+        return metricList, nil
+}
+
 // GetCachedNetworkMetric
 func (ms *MetricStore) GetCachedNetworkMetric(src string, dst string) (metric NetworkMetric, err error) {
 	// Make sure we have set a store
@@ -95,6 +127,7 @@ func (ms *MetricStore) GetCachedNetworkMetric(src string, dst string) (metric Ne
 		log.Error("Failed to retrieve metrics with error: ", err.Error())
 		return
 	}
+
 	if len(valuesArray) != 1 {
 		err = errors.New("Metric list length != 1")
 		return

--- a/go-packages/meep-metric-store/network_test.go
+++ b/go-packages/meep-metric-store/network_test.go
@@ -112,6 +112,18 @@ func TestNetworkMetricGetSet(t *testing.T) {
 		t.Fatalf("Invalid network metric")
 	}
 
+	fmt.Println("Get cached network metrics (* -> node1)")
+	nmArray, err := ms.GetCachedNetworkMetrics("*", "node1")
+	if err != nil {
+		t.Fatalf("Failed to get metric")
+	}
+	if len(nmArray) != 1 {
+		t.Fatalf("Did not received the expected number of slices (=1)")
+	}
+	if !validateNetworkMetric(nmArray[0], 2, 3.1, 2.1, 3.2, 2.2) {
+		t.Fatalf("Invalid network metric")
+	}
+
 	// GET/SET METRICS
 
 	fmt.Println("Get empty metric")


### PR DESCRIPTION
Implementation of the content of the L2Meas

using query parameters such as:
- app_instance_id
- cellId
- ipaddress field (name of the ue based on model)

implementation of the content:
cellInfo
- number of UEs (nongbr)
- delay (air interface)
- packet loss (air interface)

cellUEInfo
- delay (air interface only)
- packet loss (some of all apps, so calculated) integer 0..100 base on packet loss between 10^-4 to 10^-6 as per spec
- throuput (calculated)
- dataVolume (calculated)

Note: packet loss is not so representative (pretty baniry at the moment, either 0 or 100) because packet loss is minimum 0.01 ( value in the hundredth, rather than micro as per spec)... this limitation needs to be lifted. Tracked by another issue. 

Implementation explanation:
- RNIS now connectes to two different REDIS DB (rnis data itself populated by the sbi and table 0 where data collected from sidecar is stored)
- added more info in the redis rnis table for quicker access and more info such as the apps running on the ue so that it gets the data collected more easily (data collected based on meApp by sidecar, no knowledge of UE it belongs to)

testing:
ut passed
