### PR TITLE
Upgraded CouchDB helm charts

### DIFF
--- a/charts/couchdb/Chart.yaml
+++ b/charts/couchdb/Chart.yaml
@@ -1,13 +1,19 @@
-appVersion: 2.1.1
+apiVersion: v2
+appVersion: 3.1.0
 description: A database featuring seamless multi-master sync, that scales from big
   data to mobile, with an intuitive HTTP/JSON API and designed for reliability.
 home: https://couchdb.apache.org/
 icon: http://couchdb.apache.org/CouchDB-visual-identity/logo/CouchDB-couch-symbol.svg
+keywords:
+- couchdb
+- database
+- nosql
 maintainers:
 - email: kocolosk@apache.org
   name: kocolosk
+- email: willholley@apache.org
+  name: willholley
 name: couchdb
 sources:
-- https://github.com/apache/couchdb
-- https://github.com/kocolosk/couchdb-statefulset-assembler
-version: 0.1.6
+- https://github.com/apache/couchdb-docker
+version: 3.3.4

--- a/charts/couchdb/README.md
+++ b/charts/couchdb/README.md
@@ -14,20 +14,35 @@ storage volumes to each Pod in the Deployment.
 ## TL;DR
 
 ```bash
-$ helm install incubator/couchdb --set allowAdminParty=true
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+$ helm install couchdb/couchdb \
+  --set allowAdminParty=true \
+  --set couchdbConfig.couchdb.uuid=$(curl https://www.uuidgenerator.net/api/version4 2>/dev/null | tr -d -)
 ```
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.9+ with Beta APIs enabled
+- Ingress requires Kubernetes 1.14+
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
+Add the CouchDB Helm repository:
+
 ```bash
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install --name my-release incubator/couchdb
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+```
+
+Afterwards install the chart replacing the UUID
+`decafbaddecafbaddecafbaddecafbad` with a custom one:
+
+```bash
+$ helm install \
+  --name my-release \
+  --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
+  couchdb/couchdb
 ```
 
 This will create a Secret containing the admin credentials for the cluster.
@@ -44,10 +59,31 @@ Secret containing `adminUsername`, `adminPassword` and `cookieAuthSecret` keys:
 $  kubectl create secret generic my-release-couchdb --from-literal=adminUsername=foo --from-literal=adminPassword=bar --from-literal=cookieAuthSecret=baz
 ```
 
+If you want to set the `adminHash` directly to achieve consistent salts between 
+different nodes you need to addionally add the key `password.ini` to the secret:
+
+```bash
+$  kubectl create secret generic my-release-couchdb \
+   --from-literal=adminUsername=foo \
+   --from-literal=cookieAuthSecret=baz \
+   --from-file=./my-password.ini 
+```
+
+With the following contents in `my-password.ini`:
+
+```
+[admins]
+foo = <pbkdf2-hash>
+```
+
 and then install the chart while overriding the `createAdminSecret` setting:
 
 ```bash
-$ helm install --name my-release --set createAdminSecret=false incubator/couchdb
+$ helm install \
+  --name my-release \
+  --set createAdminSecret=false \
+  --set couchdbConfig.couchdb.uuid=decafbaddecafbaddecafbaddecafbad \
+  couchdb/couchdb
 ```
 
 This Helm chart deploys CouchDB on the Kubernetes cluster in a default
@@ -67,6 +103,34 @@ $ helm delete my-release
 The command removes all the Kubernetes components associated with the chart and
 deletes the release.
 
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v0.2.3 -> v1.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrade to 3.0.0
+
+Since version 3.0.0 setting the CouchDB server instance UUID is mandatory.
+Therefore you need to generate a UUID and supply it as a value during the
+upgrade as follows:
+
+```bash
+$ helm upgrade <release-name> \
+  --reuse-values \
+  --set couchdbConfig.couchdb.uuid=<UUID> \
+  couchdb/couchdb
+```
+
+## Migrating from stable/couchdb
+
+This chart replaces the `stable/couchdb` chart previously hosted by Helm and continues the
+version semantics. You can upgrade directly from `stable/couchdb` to this chart using:
+
+```bash
+$ helm repo add couchdb https://apache.github.io/couchdb-helm
+$ helm upgrade my-release couchdb/couchdb
+```
+
 ## Configuration
 
 The following table lists the most commonly configured parameters of the
@@ -75,35 +139,106 @@ CouchDB chart and their default values:
 |           Parameter             |             Description                               |                Default                 |
 |---------------------------------|-------------------------------------------------------|----------------------------------------|
 | `clusterSize`                   | The initial number of nodes in the CouchDB cluster    | 3                                      |
-| `couchdbConfig`                 | Map allowing override elements of server .ini config  | {}                                     |
+| `couchdbConfig`                 | Map allowing override elements of server .ini config  | *See below*                            |
 | `allowAdminParty`               | If enabled, start cluster without admin account       | false (requires creating a Secret)     |
 | `createAdminSecret`             | If enabled, create an admin account and cookie secret | true                                   |
+| `schedulerName`                 | Name of the k8s scheduler (other than default)        | `nil`                                  |
 | `erlangFlags`                   | Map of flags supplied to the underlying Erlang VM     | name: couchdb, setcookie: monster
 | `persistentVolume.enabled`      | Boolean determining whether to attach a PV to each node | false
 | `persistentVolume.size`         | If enabled, the size of the persistent volume to attach                          | 10Gi
+| `enableSearch`                  | Adds a sidecar for Lucene-powered text search         | false                                  |
+
+You can set the values of the `couchdbConfig` map according to the
+[official configuration][4]. The following shows the map's default values and
+required options to set:
+
+|           Parameter             |             Description                                            |                Default                 |
+|---------------------------------|--------------------------------------------------------------------|----------------------------------------|
+| `couchdb.uuid`                  | UUID for this CouchDB server instance ([Required in a cluster][5]) |                                        |
+| `chttpd.bind_address`           | listens on all interfaces when set to any                          | any                                    |
+| `chttpd.require_valid_user`     | disables all the anonymous requests to the port 5984 when true     | false                                  |
 
 A variety of other parameters are also configurable. See the comments in the
 `values.yaml` file for further details:
 
-|           Parameter             |                Default                 |
-|---------------------------------|----------------------------------------|
-| `adminUsername`                 | admin                                  |
-| `adminPassword`                 | auto-generated                         |
-| `cookieAuthSecret`              | auto-generated                         |
-| `helperImage.repository`        | kocolosk/couchdb-statefulset-assembler |
-| `helperImage.tag`               | 0.1.0                                  |
-| `helperImage.pullPolicy`        | IfNotPresent                           |
-| `image.repository`              | couchdb                                |
-| `image.tag`                     | 2.1.1                                  |
-| `image.pullPolicy`              | IfNotPresent                           |
-| `ingress.enabled`               | false                                  |
-| `ingress.hosts`                 | chart-example.local                    |
-| `ingress.annotations`           |                                        |
-| `ingress.tls`                   |                                        |
-| `persistentVolume.accessModes`  | ReadWriteOnce                          |
-| `persistentVolume.storageClass` | Default for the Kube cluster           |
-| `podManagementPolicy`           | Parallel                               |
-| `resources`                     |                                        |
-| `service.enabled`               | true                                   |
-| `service.type`                  | ClusterIP                              |
-| `service.externalPort`          | 5984                                   |
+|           Parameter                  |                Default                 |
+|--------------------------------------|----------------------------------------|
+| `adminUsername`                      | admin                                  |
+| `adminPassword`                      | auto-generated                         |
+| `adminHash`                          |                                        |
+| `cookieAuthSecret`                   | auto-generated                         |
+| `image.repository`                   | couchdb                                |
+| `image.tag`                          | 3.1.0                                  |
+| `image.pullPolicy`                   | IfNotPresent                           |
+| `searchImage.repository`             | kocolosk/couchdb-search                |
+| `searchImage.tag`                    | 0.1.0                                  |
+| `searchImage.pullPolicy`             | IfNotPresent                           |
+| `initImage.repository`               | busybox                                |
+| `initImage.tag`                      | latest                                 |
+| `initImage.pullPolicy`               | Always                                 |
+| `ingress.enabled`                    | false                                  |
+| `ingress.hosts`                      | chart-example.local                    |
+| `ingress.annotations`                |                                        |
+| `ingress.path`                       | /                                      |
+| `ingress.tls`                        |                                        |
+| `persistentVolume.accessModes`       | ReadWriteOnce                          |
+| `persistentVolume.storageClass`      | Default for the Kube cluster           |
+| `podManagementPolicy`                | Parallel                               |
+| `affinity`                           |                                        |
+| `annotations`                        |                                        |
+| `tolerations`                        |                                        |
+| `resources`                          |                                        |
+| `service.annotations`                |                                        |
+| `service.enabled`                    | true                                   |
+| `service.type`                       | ClusterIP                              |
+| `service.externalPort`               | 5984                                   |
+| `dns.clusterDomainSuffix`            | cluster.local                          |
+| `networkPolicy.enabled`              | true                                   |
+| `serviceAccount.enabled`             | true                                   |
+| `serviceAccount.create`              | true                                   |
+| `serviceAccount.imagePullSecrets`    |                                        |
+| `sidecars`                           | {}                                     |
+| `livenessProbe.enabled`              | true                                   |
+| `livenessProbe.failureThreshold`     | 3                                      |
+| `livenessProbe.initialDelaySeconds`  | 0                                      |
+| `livenessProbe.periodSeconds`        | 10                                     |
+| `livenessProbe.successThreshold`     | 1                                      |
+| `livenessProbe.timeoutSeconds`       | 1                                      |
+| `readinessProbe.enabled`             | true                                   |
+| `readinessProbe.failureThreshold`    | 3                                      |
+| `readinessProbe.initialDelaySeconds` | 0                                      |
+| `readinessProbe.periodSeconds`       | 10                                     |
+| `readinessProbe.successThreshold`    | 1                                      |
+| `readinessProbe.timeoutSeconds`      | 1                                      |
+
+## Feedback, Issues, Contributing
+
+General feedback is welcome at our [user][1] or [developer][2] mailing lists.
+
+Apache CouchDB has a [CONTRIBUTING][3] file with details on how to get started
+with issue reporting or contributing to the upkeep of this project. In short,
+use GitHub Issues, do not report anything on Docker's website.
+
+## Non-Apache CouchDB Development Team Contributors
+
+- [@natarajaya](https://github.com/natarajaya)
+- [@satchpx](https://github.com/satchpx)
+- [@spanato](https://github.com/spanato)
+- [@jpds](https://github.com/jpds)
+- [@sebastien-prudhomme](https://github.com/sebastien-prudhomme)
+- [@stepanstipl](https://github.com/sebastien-stepanstipl)
+- [@amatas](https://github.com/amatas)
+- [@Chimney42](https://github.com/Chimney42)
+- [@mattjmcnaughton](https://github.com/mattjmcnaughton)
+- [@mainephd](https://github.com/mainephd)
+- [@AdamDang](https://github.com/AdamDang)
+- [@mrtyler](https://github.com/mrtyler)
+- [@kevinwlau](https://github.com/kevinwlau)
+- [@jeyenzo](https://github.com/jeyenzo)
+- [@Pinpin31.](https://github.com/Pinpin31)
+
+[1]: http://mail-archives.apache.org/mod_mbox/couchdb-user/
+[2]: http://mail-archives.apache.org/mod_mbox/couchdb-dev/
+[3]: https://github.com/apache/couchdb/blob/master/CONTRIBUTING.md
+[4]: https://docs.couchdb.org/en/stable/config/index.html
+[5]: https://docs.couchdb.org/en/latest/setup/cluster.html#preparing-couchdb-nodes-to-be-joined-into-a-cluster

--- a/charts/couchdb/ci/required-values.yaml
+++ b/charts/couchdb/ci/required-values.yaml
@@ -1,0 +1,3 @@
+couchdbConfig:
+  couchdb:
+    uuid: "decafbaddecafbaddecafbaddecafbad"

--- a/charts/couchdb/ci/sidecar.yaml
+++ b/charts/couchdb/ci/sidecar.yaml
@@ -1,0 +1,9 @@
+sidecars:
+  - name: foo
+    image: "busybox"
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "0.1"
+        memory: 10Mi
+    command: ['while true; do echo "foo"; sleep 5; done;']

--- a/charts/couchdb/password.ini
+++ b/charts/couchdb/password.ini
@@ -1,0 +1,2 @@
+[admins]
+{{ .Values.adminUsername }} = {{ .Values.adminHash }}

--- a/charts/couchdb/templates/_helpers.tpl
+++ b/charts/couchdb/templates/_helpers.tpl
@@ -42,3 +42,40 @@ Create a random string if the supplied key does not exist
 {{- randAlphaNum 20 | b64enc | quote -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Labels used to define Pods in the CouchDB statefulset
+*/}}
+{{- define "couchdb.ss.selector" -}}
+app: {{ template "couchdb.name" . }}
+release: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Generates a comma delimited list of nodes in the cluster
+*/}}
+{{- define "couchdb.seedlist" -}}
+{{- $nodeCount :=  min 5 .Values.clusterSize | int }}
+  {{- range $index0 := until $nodeCount -}}
+    {{- $index1 := $index0 | add1 -}}
+    {{ $.Values.erlangFlags.name }}@{{ template "couchdb.fullname" $ }}-{{ $index0 }}.{{ template "couchdb.fullname" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.dns.clusterDomainSuffix }}{{ if ne $index1 $nodeCount }},{{ end }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+If serviceAccount.name is specified, use that, else use the couchdb instance name
+*/}}
+{{- define "couchdb.serviceAccount" -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name }}
+{{- else -}}
+{{- template "couchdb.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fail if couchdbConfig.couchdb.uuid is undefined
+*/}}
+{{- define "couchdb.uuid" -}}
+{{- required "A value for couchdbConfig.couchdb.uuid must be set" (.Values.couchdbConfig.couchdb | default dict).uuid -}}
+{{- end -}} 

--- a/charts/couchdb/templates/configmap.yaml
+++ b/charts/couchdb/templates/configmap.yaml
@@ -10,9 +10,15 @@ metadata:
     meepOrigin: {{ .Values.meepOrigin }}
 data:
   inifile: |
-    {{ range $section, $settings := .Values.couchdbConfig -}}
+    {{ $couchdbConfig := dict "couchdb" (dict "uuid" (include "couchdb.uuid" .)) -}}
+    {{- $couchdbConfig := merge $couchdbConfig .Values.couchdbConfig -}}
+    {{- range $section, $settings := $couchdbConfig -}}
     {{ printf "[%s]" $section }}
     {{ range $key, $value := $settings -}}
     {{ printf "%s = %s" $key ($value | toString) }}
     {{ end }}
     {{ end }}
+
+  seedlistinifile: |
+    [cluster]
+    seedlist = {{ template "couchdb.seedlist" . }}

--- a/charts/couchdb/templates/ingress.yaml
+++ b/charts/couchdb/templates/ingress.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "couchdb.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+{{- $path := .Values.ingress.path | quote -}}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "couchdb.fullname" . }}
@@ -21,7 +22,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/charts/couchdb/templates/networkpolicy.yaml
+++ b/charts/couchdb/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "couchdb.fullname" . }}
+  labels:
+    app: {{ template "couchdb.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    meepOrigin: {{ .Values.meepOrigin }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "couchdb.ss.selector" . | indent 6 }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 5984
+    - ports:
+        - protocol: TCP
+          port: 9100
+        - protocol: TCP
+          port: 4369
+      from:
+        - podSelector:
+            matchLabels:
+{{ include "couchdb.ss.selector" . | indent 14 }}
+  policyTypes:
+    - Ingress
+{{- end }}

--- a/charts/couchdb/templates/persistentvolume.yaml
+++ b/charts/couchdb/templates/persistentvolume.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    meepOrigin: {{ .Values.meepOrigin }}
 spec:
   capacity:
     storage: {{ .Values.persistentVolume.size }}

--- a/charts/couchdb/templates/persistentvolumeclaim.yaml
+++ b/charts/couchdb/templates/persistentvolumeclaim.yaml
@@ -12,6 +12,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    meepOrigin: {{ .Values.meepOrigin }}
   name: {{ template "couchdb.fullname" . }}
 spec:
   accessModes:

--- a/charts/couchdb/templates/secrets.yaml
+++ b/charts/couchdb/templates/secrets.yaml
@@ -14,4 +14,7 @@ data:
   adminUsername: {{ template "couchdb.defaultsecret" .Values.adminUsername }}
   adminPassword: {{ template "couchdb.defaultsecret" .Values.adminPassword }}
   cookieAuthSecret: {{ template "couchdb.defaultsecret" .Values.cookieAuthSecret }}
+{{- if  .Values.adminHash  }}
+  password.ini: {{ tpl (.Files.Get "password.ini") . | b64enc }}
+{{- end -}}
 {{- end -}}

--- a/charts/couchdb/templates/service.yaml
+++ b/charts/couchdb/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     meepOrigin: {{ .Values.meepOrigin }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   ports:
     - port: {{ .Values.service.externalPort }}
@@ -19,6 +23,5 @@ spec:
       {{- end }}
   type: {{ .Values.service.type }}
   selector:
-    app: {{ template "couchdb.name" . }}
-    release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 4 }}
 {{- end -}}

--- a/charts/couchdb/templates/serviceaccount.yaml
+++ b/charts/couchdb/templates/serviceaccount.yaml
@@ -1,18 +1,16 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
-kind: Service
+kind: ServiceAccount
 metadata:
-  name: {{ template "couchdb.fullname" . }}
+  name: {{ template "couchdb.serviceAccount" . }}
   labels:
     app: {{ template "couchdb.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     meepOrigin: {{ .Values.meepOrigin }}
-spec:
-  clusterIP: None
-  publishNotReadyAddresses: true
-  ports:
-    - name: couchdb
-      port: 5984
-  selector:
-{{ include "couchdb.ss.selector" . | indent 4 }}
+{{- if .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.serviceAccount.imagePullSecrets }}
+{{- end }}
+{{- end }}

--- a/charts/couchdb/templates/statefulset.yaml
+++ b/charts/couchdb/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion:  apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "couchdb.fullname" . }}
@@ -14,25 +14,46 @@ spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   selector:
     matchLabels:
-      app: {{ template "couchdb.name" . }}
-      release: {{ .Release.Name }}
+{{ include "couchdb.ss.selector" . | indent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "couchdb.name" . }}
-        release: {{ .Release.Name }}
         meepOrigin: {{ .Values.meepOrigin }}
+{{ include "couchdb.ss.selector" . | indent 8 }}
+{{- with .Values.annotations }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ template "couchdb.serviceAccount" . }}
+      {{- end }}
       initContainers:
         - name: init-copy
-          image: busybox
-          imagePullPolicy: IfNotPresent
-          command: ['sh','-c','cp /tmp/chart.ini /default.d; ls -lrt /default.d;']
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command: ['sh','-c','cp /tmp/chart.ini /default.d; cp /tmp/seedlist.ini /default.d; ls -lrt /default.d;']
           volumeMounts:
           - name: config
             mountPath: /tmp/
           - name: config-storage
             mountPath: /default.d
+{{- if .Values.adminHash }}
+        - name: admin-hash-copy
+          image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command: ['sh','-c','cp /tmp/password.ini /local.d/ ;']
+          volumeMounts:
+            - name: admin-password
+              mountPath: /tmp/password.ini
+              subPath: "password.ini"
+            - name: local-config-storage
+              mountPath: /local.d
+{{- end }}
       containers:
         - name: couchdb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -63,22 +84,79 @@ spec:
 {{- end }}
             - name: ERL_FLAGS
               value: "{{ range $k, $v := .Values.erlangFlags }} -{{ $k }} {{ $v }} {{ end }}"
+{{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+{{- if .Values.couchdbConfig.chttpd.require_valid_user }}
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/_up
+{{- else }}
+            httpGet:
+              path: /_up
+              port: 5984
+{{- end }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+{{- if .Values.couchdbConfig.chttpd.require_valid_user }}
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -G --silent --fail -u ${COUCHDB_USER}:${COUCHDB_PASSWORD} http://localhost:5984/_up
+{{- else }}
+            httpGet:
+              path: /_up
+              port: 5984
+{{- end }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           - name: config-storage
             mountPath: /opt/couchdb/etc/default.d
+{{- if .Values.adminHash }}
+          - name: local-config-storage
+            mountPath: /opt/couchdb/etc/local.d
+{{- end }}
           - name: database-storage
             mountPath: /opt/couchdb/data
+{{- if .Values.enableSearch }}
+        - name: clouseau
+          image: "{{ .Values.searchImage.repository }}:{{ .Values.searchImage.tag }}"
+          imagePullPolicy: {{ .Values.searchImage.pullPolicy }}
+          volumeMounts:
+          - name: database-storage
+            mountPath: /opt/couchdb-search/data
+{{- end }}
+{{- if .Values.sidecars }}
+{{ toYaml .Values.sidecars | indent 8}}
+{{- end }}
       terminationGracePeriodSeconds: 5
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
-      {{- if .Values.affinity }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-      {{- end }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       volumes:
         - name: config-storage
           emptyDir: {}
@@ -88,6 +166,17 @@ spec:
             items:
               - key: inifile
                 path: chart.ini
+              - key: seedlistinifile
+                path: seedlist.ini
+
+{{- if .Values.adminHash }}
+        - name: local-config-storage
+          emptyDir: {}
+        - name: admin-password
+          secret:
+            secretName: {{ template "couchdb.fullname" . }}
+{{- end -}}
+
 {{- if not .Values.persistentVolume.enabled }}
         - name: database-storage
           emptyDir: {}

--- a/charts/couchdb/templates/storageclass.yaml
+++ b/charts/couchdb/templates/storageclass.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    meepOrigin: {{ .Values.meepOrigin }}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 {{- end }}

--- a/charts/couchdb/values.yaml
+++ b/charts/couchdb/values.yaml
@@ -1,5 +1,4 @@
 ## clusterSize is the initial size of the CouchDB cluster.
-#clusterSize: 3
 clusterSize: 1
 
 ## If allowAdminParty is enabled the cluster will start up without any database
@@ -14,9 +13,10 @@ allowAdminParty: true
 ## be created containing auto-generated credentials. Users who prefer to set
 ## these values themselves have a couple of options:
 ##
-## 1) The `adminUsername`, `adminPassword`, and `cookieAuthSecret` can be
-##    defined directly in the chart's values. Note that all of a chart's values
-##    are currently stored in plaintext in a ConfigMap in the tiller namespace.
+## 1) The `adminUsername`, `adminPassword`, `adminHash`, and `cookieAuthSecret`
+##    can be defined directly in the chart's values. Note that all of a chart's
+##    values are currently stored in plaintext in a ConfigMap in the tiller
+##    namespace.
 ##
 ## 2) This flag can be disabled and a Secret with the required keys can be
 ##    created ahead of time.
@@ -24,7 +24,27 @@ createAdminSecret: true
 
 adminUsername: admin
 adminPassword: admin
+adminHash: admin
+# adminHash: -pbkdf2-this_is_not_necessarily_secure_either
 # cookieAuthSecret: neither_is_this
+
+## When enabled, will deploy a networkpolicy that allows CouchDB pods to
+## communicate with each other for clustering and ingress on port 5984
+networkPolicy:
+  enabled: true
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+# Use a service account
+serviceAccount:
+  enabled: true
+  create: true
+# name:
+# imagePullSecrets:
+# - name: myimagepullsecret
 
 ## The storage volume used by each Pod in the StatefulSet. If a
 ## persistentVolume is not enabled, the Pods will use `emptyDir` ephemeral
@@ -61,13 +81,21 @@ persistentVolumeClaim:
 ## The CouchDB image
 image:
   repository: couchdb
-  tag: 2.1.1
+  tag: 3.1.0
   pullPolicy: IfNotPresent
 
-## Sidecar that connects the individual Pods into a cluster
-helperImage:
-  repository: kocolosk/couchdb-statefulset-assembler
-  tag: 1.1.0
+## Experimental integration with Lucene-powered fulltext search
+searchImage:
+  repository: kocolosk/couchdb-search
+  tag: 0.2.0
+  pullPolicy: IfNotPresent
+
+## Flip this to flag to include the Search container in each Pod
+enableSearch: false
+
+initImage:
+  repository: busybox
+  tag: latest
   pullPolicy: IfNotPresent
 
 ## CouchDB is happy to spin up cluster nodes in parallel, but if you encounter
@@ -75,16 +103,42 @@ helperImage:
 ## `OrderedReady`
 podManagementPolicy: Parallel
 
+## To better tolerate Node failures, we can prevent Kubernetes scheduler from
+## assigning more than one Pod of CouchDB StatefulSet per Node using podAntiAffinity.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+  # podAntiAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #           - key: "app"
+  #             operator: In
+  #             values:
+  #             - couchdb
+  #       topologyKey: "kubernetes.io/hostname"
+
+## Optional pod annotations
+annotations: {}
+
+## Optional tolerations
+tolerations: []
+
 ## A StatefulSet requires a headless Service to establish the stable network
 ## identities of the Pods, and that Service is created automatically by this
 ## chart without any additional configuration. The Service block below refers
 ## to a second Service that governs how clients connect to the CouchDB cluster.
 service:
+  # annotations:
   enabled: true
   type: ClusterIP
-  #type: NodePort
+  # type: NodePort
   externalPort: 5984
-  #nodePort: 30984
+  # nodePort: 30984
 
 ## An Ingress resource can provide name-based virtual hosting and TLS
 ## termination among other things for CouchDB deployments which are accessed
@@ -94,7 +148,8 @@ ingress:
   enabled: false
   hosts:
     - chart-example.local
-  annotations:
+  path: /
+  annotations: []
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:
@@ -105,7 +160,8 @@ ingress:
 
 ## Optional resource requests and limits for the CouchDB container
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-resources: {}
+resources:
+  {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
@@ -126,15 +182,51 @@ erlangFlags:
 ## by a ConfigMap object.
 ## ref: http://docs.couchdb.org/en/latest/config/index.html
 couchdbConfig:
+  couchdb:
+   uuid: c73e1bda6b67472e80c1aeb05dcfb6c9
   # cluster:
   #   q: 8 # Create 8 shards for each database
+  chttpd:
+    bind_address: any
+    # chttpd.require_valid_user disables all the anonymous requests to the port
+    # 5984 when is set to true.
+    require_valid_user: false
+
+# Kubernetes local cluster domain.
+# This is used to generate FQDNs for peers when joining the CouchDB cluster.
+dns:
+  clusterDomainSuffix: cluster.local
+
+## Configure liveness and readiness probe values
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+livenessProbe:
+  enabled: false
+  failureThreshold: 3
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+readinessProbe:
+  enabled: false
+  failureThreshold: 3
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
+# Configure arbitrary sidecar containers for CouchDB pods created by the
+# StatefulSet
+sidecars: {}
+  # - name: foo
+  #   image: "busybox"
+  #   imagePullPolicy: IfNotPresent
+  #   resources:
+  #     requests:
+  #       cpu: "0.1"
+  #       memory: 10Mi
+  #   command: ['echo "foo";']
+  #   volumeMounts:
+  #     - name: database-storage
+  #       mountPath: /opt/couchdb/data/
 
 meepOrigin: core
-
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: node-role.kubernetes.io/master
-          operator: Exists

--- a/charts/kube-prometheus-stack/charts/prometheus-couchdb-exporter/values.yaml
+++ b/charts/kube-prometheus-stack/charts/prometheus-couchdb-exporter/values.yaml
@@ -62,11 +62,11 @@ affinity: {}
 ## CouchDB exporter configurations
 couchdb:
   ## URI of the couchdb instance
-  uri: http://meep-couchdb-svc-couchdb.default.svc.cluster.local:5984/
+  uri: http://meep-couchdb-svc-couchdb:5984/
   ## Specify the list of databases to get the disk usage stats as comma separates like "db-1,db-2"
   ## or to get stats for every database, please use "_all_dbs"
   databases: _all_dbs
-  ## CouchDB username
-  # username:
-  ## CouchDB Password
-  # password:
+  # CouchDB username
+  username: admin
+  # CouchDB Password
+  password: admin

--- a/go-apps/meep-auth-svc/go.mod
+++ b/go-apps/meep-auth-svc/go.mod
@@ -12,18 +12,14 @@ require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store v0.0.0 // indirect
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sessions v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-users v0.0.0
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/lkysow/go-gitlab v0.7.1
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/prometheus/client_golang v1.9.0
 	github.com/roymx/viper v1.3.3-0.20190416163942-b9a223fc58a3
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
 
 replace (

--- a/go-apps/meep-mon-engine/go.mod
+++ b/go-apps/meep-mon-engine/go.mod
@@ -9,16 +9,10 @@ require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store v0.0.0
-	github.com/gogo/protobuf v1.2.1 // indirect
-	github.com/google/btree v1.0.0 // indirect
-	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gregjones/httpcache v0.0.0-20190212212710-3befbb6ad0cc // indirect
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v1.9.0
 	github.com/spf13/pflag v1.0.3 // indirect
@@ -28,7 +22,6 @@ require (
 	k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
 	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/klog v0.0.0-20181108234604-8139d8cb77af // indirect
-	sigs.k8s.io/yaml v1.1.0 // indirect
 )
 
 replace (

--- a/go-apps/meep-platform-ctrl/go.mod
+++ b/go-apps/meep-platform-ctrl/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-sandbox-store v0.0.0
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/handlers v1.4.0
@@ -21,7 +20,6 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/roymx/viper v1.3.3-0.20190416163942-b9a223fc58a3 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
-	google.golang.org/protobuf v1.25.0 // indirect
 )
 
 replace (

--- a/go-apps/meep-tc-sidecar/go.mod
+++ b/go-apps/meep-tc-sidecar/go.mod
@@ -9,10 +9,6 @@ require (
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-mq v0.0.0
 	github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-redis v0.0.0
 	github.com/coreos/go-iptables v0.4.0
-	github.com/gogo/protobuf v1.2.1 // indirect
-	github.com/google/gofuzz v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	gopkg.in/inf.v0 v0.9.1 // indirect
@@ -21,7 +17,6 @@ require (
 	k8s.io/klog v0.0.0-20181108234604-8139d8cb77af // indirect
 	k8s.io/kubernetes v1.13.4
 	k8s.io/utils v0.0.0-20190221042446-c2654d5206da
-	sigs.k8s.io/yaml v1.1.0 // indirect
 )
 
 replace (

--- a/go-packages/meep-couch/db.go
+++ b/go-packages/meep-couch/db.go
@@ -18,6 +18,7 @@ package couchdb
 
 import (
 	"context"
+	"strings"
 
 	"github.com/flimzy/kivik"
 	_ "github.com/go-kivik/couchdb"
@@ -54,7 +55,10 @@ func NewConnector(addr string, dbName string) (rc *Connector, err error) {
 		} else {
 			c.addr = addr
 		}
-		c.dbClient, err = kivik.New(context.TODO(), "couch", addr)
+
+		var address []string = strings.SplitAfter(addr, "http://")
+		var newAddr = address[0] + "admin:admin@" + address[1]
+		c.dbClient, err = kivik.New(context.TODO(), "couch", newAddr)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Changes:
- Upgraded CouchDB helm chart which uses latest CouchDB v3.
- CouchDB v3 doesn't support connecting to DB without username and password so enabled admin login and changed `db.go` to connect with login information

Testing:
- All UT and Cypress test cases passed
- Verified scenario data retention manually after upgrade