### PR TITLE
Packet loss supporting up to 6 decimals and Terminal network characteristics event fix

### DIFF
--- a/go-apps/meep-tc-engine/tc-engine.go
+++ b/go-apps/meep-tc-engine/tc-engine.go
@@ -101,7 +101,7 @@ type FilterInfo struct {
 	LatencyVariation   int
 	LatencyCorrelation int
 	Distribution       string
-	PacketLoss         int
+	PacketLoss         float64
 	DataRate           int
 }
 
@@ -610,7 +610,7 @@ func netCharUpdate(dstName string, srcName string, rate float64, latency float64
 	// Update filter info
 	filterInfo.Latency = int(latency)
 	filterInfo.LatencyVariation = int(latencyVariation)
-	filterInfo.PacketLoss = int(100 * packetLoss)
+	filterInfo.PacketLoss = packetLoss
 	filterInfo.DataRate = int(THROUGHPUT_UNIT * rate)
 	filterInfo.Distribution = strings.ToLower(distribution)
 	_ = setShapingRule(filterInfo)
@@ -662,7 +662,7 @@ func setFilterInfoRules() {
 				filterInfo.LatencyVariation = 0
 				filterInfo.LatencyCorrelation = COMMON_CORRELATION
 				filterInfo.Distribution = DEFAULT_DISTRIBUTION
-				filterInfo.PacketLoss = 0
+				filterInfo.PacketLoss = 0.0
 				filterInfo.DataRate = 0
 
 				dstElem.FilterInfoMap[srcElem.Name] = filterInfo
@@ -705,7 +705,7 @@ func setShapingRule(filterInfo *FilterInfo) error {
 	m_shape["delayVariation"] = strconv.FormatInt(int64(filterInfo.LatencyVariation), 10)
 	m_shape["delayCorrelation"] = strconv.FormatInt(int64(filterInfo.LatencyCorrelation), 10)
 	m_shape["distribution"] = filterInfo.Distribution
-	m_shape["packetLoss"] = strconv.FormatInt(int64(filterInfo.PacketLoss), 10)
+	m_shape["packetLoss"] = fmt.Sprintf("%f", filterInfo.PacketLoss)
 	m_shape["dataRate"] = strconv.FormatInt(int64(filterInfo.DataRate), 10)
 	m_shape["ifb_uniqueId"] = uniqueId
 

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -882,23 +882,7 @@ func cmdSetIfb(shape map[string]string) (bool, error) {
 	delayVariation := shape["delayVariation"]
 	delayCorrelation := shape["delayCorrelation"]
 	distribution := shape["distribution"]
-
 	loss := shape["packetLoss"]
-	var lossInteger string
-	var lossFraction string
-
-	if len(loss) > 2 {
-		lossInteger = loss[0 : len(loss)-2]
-		lossFraction = loss[len(loss)-2:]
-	} else if len(loss) > 0 {
-		// length is 1 or 2
-		lossInteger = "0"
-		lossFraction = loss
-	} else {
-		lossInteger = "0"
-		lossFraction = "00"
-	}
-
 	dataRate := shape["dataRate"]
 
 	//tc qdisc change dev $ifb$ifbnumber handle 1:0 root netem delay $delay$ms loss $loss$prcent
@@ -922,7 +906,7 @@ func cmdSetIfb(shape map[string]string) (bool, error) {
 	}
 	//only apply if an update is needed
 	if nc.Latency != delay || nc.Jitter != delayVariation || nc.PacketLoss != loss || nc.Throughput != dataRate || (delayVariation != "0" && nc.Distribution != distribution) {
-		str := "tc qdisc change dev ifb" + ifbNumber + " handle 1:0 root netem delay " + delay + "ms " + delayVariation + "ms " + delayCorrelation + "% " + distributionStr + " loss " + lossInteger + "." + lossFraction + "%"
+		str := "tc qdisc change dev ifb" + ifbNumber + " handle 1:0 root netem delay " + delay + "ms " + delayVariation + "ms " + delayCorrelation + "% " + distributionStr + " loss " + loss + "%"
 		if dataRate != "" && dataRate != "0" {
 			str = str + " rate " + dataRate + "bit"
 		}

--- a/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
+++ b/js-apps/meep-frontend/src/js/containers/exec/network-characteristics-event-pane.js
@@ -69,6 +69,7 @@ import {
   POA_5G_TYPE_STR,
   POA_WIFI_TYPE_STR,
   DC_TYPE_STR,
+  UE_TYPE_STR,
   UE_APP_TYPE_STR,
   EDGE_APP_TYPE_STR,
   CLOUD_APP_TYPE_STR
@@ -200,6 +201,9 @@ class NetworkCharacteristicsEventPane extends Component {
       break;
     case ELEMENT_TYPE_DC:
       neType = DC_TYPE_STR;
+      break;
+    case ELEMENT_TYPE_UE:
+      neType = UE_TYPE_STR;
       break;
     case ELEMENT_TYPE_UE_APP:
       neType = UE_APP_TYPE_STR;


### PR DESCRIPTION
Packet loss now supporting up to 6 decimals
Terminal network characteristics event frontend fix (was not being updated for TERMINAL type only)

UT passed







