### PR TITLE
Grafana http-aggregate logger update

### DIFF
--- a/charts/grafana/dashboards/http-loggers.json
+++ b/charts/grafana/dashboards/http-loggers.json
@@ -11,7 +11,7 @@
       "datasource": "$datasource",
       "fontSize": "100%",
       "gridPos": {
-        "h": 6,
+        "h": 20,
         "w": 24,
         "x": 0,
         "y": 3
@@ -71,7 +71,7 @@
           "link": true,
           "linkTargetBlank":true, 
           "linkTooltip": "get details",
-          "linkUrl":"grafana/d/4/http-rest-api-single-log-details?orgId=1&var-database=$database&var-logger_name=$logger_name&theme=light&refresh=1d&var-http_log_id=${__cell}",
+          "linkUrl":"d/4/http-rest-api-single-log-details?orgId=1&var-database=$database&var-logger_name=${__cell_3}&theme=light&refresh=1d&var-http_log_id=${__cell}",
           "mappingType": 1,
           "pattern": "http.id",
           "thresholds": [],
@@ -224,7 +224,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "service",
-        "multi": false,
+        "multi": true,
         "name": "logger_name",
         "options": [],
         "query": "show tag values on $database from http with key = \"logger_name\"",


### PR DESCRIPTION
4 changes provided to update the dashboard http-log- aggregation

1) Changed the services to have a multi select
2) Updated the size of the results to 20 lines rather than 6
3-4) Updated the link to point to a valid location (removal duplication of grafana in url) and update for the service to be the one matching the cell that was clicked(rather than the value stored in the select dropdown)

manual testing done only