### PR TITLE
App Lifecycle: MG Manager support

### DIFF
--- a/go-apps/meep-mg-manager/server/mg-manager.go
+++ b/go-apps/meep-mg-manager/server/mg-manager.go
@@ -941,6 +941,9 @@ func mgAppCreate(mgName string, mgApp *mgModel.MobilityGroupApp) error {
 	// Store & Apply latest MG Service mappings
 	applyMgSvcMapping()
 
+	// Inform TC Engine of LB rules updatge
+	publishLbRulesUpdate()
+
 	return nil
 }
 
@@ -1038,6 +1041,9 @@ func mgUeCreate(mgName string, appID string, mgUe *mgModel.MobilityGroupUe) erro
 
 		// Store & Apply latest MG Service mappings
 		applyMgSvcMapping()
+
+		// Inform TC Engine of LB rules updatge
+		publishLbRulesUpdate()
 	}
 	return nil
 }

--- a/go-apps/meep-mg-manager/server/mg-manager.go
+++ b/go-apps/meep-mg-manager/server/mg-manager.go
@@ -85,6 +85,9 @@ const lbAlgoHopCount = "HOP-COUNT"
 // const lbAlgoDistance = "DISTANCE"
 // const lbAlgoNone = "NONE"
 
+// MQ payload fields
+const fieldEventType = "event-type"
+
 type mgInfo struct {
 	mg                  mgModel.MobilityGroup
 	appInfoMap          map[string]*appInfo
@@ -151,10 +154,6 @@ type MgManager struct {
 	svcInfoMap   map[string]*serviceInfo
 	mgSvcInfoMap map[string]*mgServiceInfo
 
-	// mapping from element name to svc name for usercharts
-	svcToElemMap map[string]string
-	elemToSvcMap map[string]string
-
 	// Network Element Info mapping
 	netElemInfoMap map[string]*netElemInfo
 
@@ -170,8 +169,6 @@ func Init() (err error) {
 	mgm.netLocList = make([]string, 0)
 	mgm.svcInfoMap = make(map[string]*serviceInfo)
 	mgm.mgSvcInfoMap = make(map[string]*mgServiceInfo)
-	mgm.svcToElemMap = make(map[string]string)
-	mgm.elemToSvcMap = make(map[string]string)
 	mgm.netElemInfoMap = make(map[string]*netElemInfo)
 	mgm.mgInfoMap = make(map[string]*mgInfo)
 
@@ -222,7 +219,7 @@ func Init() (err error) {
 	_ = mgm.lbRulesStore.rc.DBFlush(mgm.baseKey)
 
 	// Initialize Edge-LB rules with current active scenario
-	processActiveScenarioUpdate()
+	processScenarioActivate()
 
 	return nil
 }
@@ -246,34 +243,66 @@ func msgHandler(msg *mq.Msg, userData interface{}) {
 	switch msg.Message {
 	case mq.MsgScenarioActivate:
 		log.Debug("RX MSG: ", mq.PrintMsg(msg))
-		processActiveScenarioUpdate()
+		processScenarioActivate()
 	case mq.MsgScenarioUpdate:
 		log.Debug("RX MSG: ", mq.PrintMsg(msg))
-		processActiveScenarioUpdate()
+		eventType := msg.Payload[fieldEventType]
+		processScenarioUpdate(eventType)
 	case mq.MsgScenarioTerminate:
 		log.Debug("RX MSG: ", mq.PrintMsg(msg))
-		processActiveScenarioUpdate()
+		processScenarioTerminate()
 	default:
 		log.Trace("Ignoring unsupported message: ", mq.PrintMsg(msg))
 	}
 }
 
-func processActiveScenarioUpdate() {
+func processScenarioActivate() {
 
 	// Sync with active scenario store
 	mgm.activeModel.UpdateScenario()
 
-	scenarioName := mgm.activeModel.GetScenarioName()
-	if mgm.scenarioName != scenarioName {
-		mgm.scenarioName = scenarioName
-		_ = httpLog.ReInit(moduleName, mgm.sandboxName, scenarioName, redisAddr, influxAddr)
-	}
-
-	// Handle empty/missing scenario
-	if scenarioName == "" {
-		clearScenario()
+	// Get scenario name
+	mgm.scenarioName = mgm.activeModel.GetScenarioName()
+	if mgm.scenarioName == "" {
+		log.Error("Failed to find active scenario")
 		return
 	}
+
+	// Initialize HTTP metrics logger with scenario name
+	_ = httpLog.ReInit(moduleName, mgm.sandboxName, mgm.scenarioName, redisAddr, influxAddr)
+
+	// Parse scenario
+	err := processScenario(mgm.activeModel)
+	if err != nil {
+		log.Error("Failed to process scenario with error: ", err.Error())
+		return
+	}
+
+	// Set Default Edge-LB mapping
+	refreshDefaultNetLocAppMaps()
+
+	// Re-evaluate MG Service mapping
+	refreshMgSvcMapping()
+
+	// Store & Apply latest MG Service mappings
+	applyMgSvcMapping()
+
+	// Inform TC Engine of LB rules updatge
+	publishLbRulesUpdate()
+}
+
+func processScenarioUpdate(eventType string) {
+
+	// Ignore unsupported update types
+	switch eventType {
+	case mod.EventMobility, mod.EventPoaInRange, mod.EventAddNode, mod.EventModifyNode, mod.EventRemoveNode:
+		break
+	default:
+		return
+	}
+
+	// Sync with active scenario store
+	mgm.activeModel.UpdateScenario()
 
 	// Parse scenario
 	err := processScenario(mgm.activeModel)
@@ -290,22 +319,40 @@ func processActiveScenarioUpdate() {
 
 	// Store & Apply latest MG Service mappings
 	applyMgSvcMapping()
+
+	// Inform TC Engine of LB rules updatge
+	publishLbRulesUpdate()
+}
+
+func processScenarioTerminate() {
+
+	// Sync with active scenario store
+	mgm.activeModel.UpdateScenario()
+
+	// Clear scenario data
+	clearScenario()
+
+	// Inform TC Engine of LB rules updatge
+	publishLbRulesUpdate()
 }
 
 func clearScenario() {
 	log.Debug("clearScenario() -- Resetting all variables")
 
+	mgm.scenarioName = ""
 	mgm.networkGraph = nil
 	mgm.netLocList = make([]string, 0)
 	mgm.svcInfoMap = make(map[string]*serviceInfo)
 	mgm.mgSvcInfoMap = make(map[string]*mgServiceInfo)
-	mgm.svcToElemMap = make(map[string]string)
-	mgm.elemToSvcMap = make(map[string]string)
 	mgm.netElemInfoMap = make(map[string]*netElemInfo)
 	mgm.mgInfoMap = make(map[string]*mgInfo)
 
 	// Flush module data and send update
 	_ = mgm.lbRulesStore.rc.DBFlush(mgm.baseKey)
+}
+
+// publishLbRulesUpdate - Inform TC Engine of LB rules update
+func publishLbRulesUpdate() {
 
 	// Send LB Rules Update message
 	msg := mgm.mqLocal.CreateMsg(mq.MsgMgLbRulesUpdate, moduleTcEngine, mgm.sandboxName)
@@ -325,6 +372,19 @@ func processScenario(model *mod.Model) error {
 
 	// Get list of processes
 	procNames := model.GetNodeNames("CLOUD-APP", "EDGE-APP", "UE-APP")
+	procNamesMap := make(map[string]bool)
+	for _, procName := range procNames {
+		procNamesMap[procName] = true
+	}
+
+	// Clear existing network element svc mappings & remove elements no longer in scenario
+	for procName, netElem := range mgm.netElemInfoMap {
+		if _, found := procNamesMap[procName]; found {
+			netElem.mgSvcMap = map[string]*svcMapInfo{}
+		} else {
+			delete(mgm.netElemInfoMap, procName)
+		}
+	}
 
 	// Get network graph from model
 	mgm.networkGraph = model.GetNetworkGraph()
@@ -433,8 +493,6 @@ func addServiceInfo(svcName string, mgSvcName string, nodeName string) {
 
 	// Add service instance to service info map
 	mgm.svcInfoMap[svcInfo.name] = svcInfo
-	mgm.svcToElemMap[svcInfo.name] = svcInfo.name
-	mgm.elemToSvcMap[svcInfo.name] = svcInfo.name
 }
 
 func getNetElem(name string) *netElemInfo {
@@ -452,18 +510,24 @@ func getNetElem(name string) *netElemInfo {
 	return netElem
 }
 
-func setDefaultNetLocAppMaps() {
-	log.Debug("setDefaultNetLocAppMaps")
+func refreshDefaultNetLocAppMaps() {
+	log.Debug("refreshDefaultNetLocAppMaps")
 
 	// For each MG Service & net location in scenario, use Group App instances from scenario and
 	// default LB algorithm to determine which App instance is best for net location
 	for _, mgInfo := range mgm.mgInfoMap {
-		// Only set on first pass
-		if len(mgInfo.defaultNetLocAppMap) == 0 {
-			for _, netLoc := range mgm.netLocList {
-				mgInfo.defaultNetLocAppMap[netLoc] = runLbAlgoHopCount(mgm.mgSvcInfoMap[mgInfo.mg.Name].services, netLoc)
-			}
+		mgInfo.defaultNetLocAppMap = make(map[string]string)
+		for _, netLoc := range mgm.netLocList {
+			mgInfo.defaultNetLocAppMap[netLoc] = runLbAlgoHopCount(mgm.mgSvcInfoMap[mgInfo.mg.Name].services, netLoc)
 		}
+	}
+}
+
+func refreshNetLocAppMaps() {
+	log.Debug("refreshNetLocAppMaps")
+
+	for _, mgInfo := range mgm.mgInfoMap {
+		refreshNetLocAppMap(mgInfo)
 	}
 }
 
@@ -477,10 +541,6 @@ func refreshNetLocAppMap(mgInfo *mgInfo) {
 	var mgApps = map[string]*serviceInfo{}
 	for _, appInfo := range mgInfo.appInfoMap {
 		mgApps[appInfo.app.Id] = mgm.svcInfoMap[appInfo.app.Id]
-		if mgApps[appInfo.app.Id] == nil {
-
-			mgApps[appInfo.app.Id] = mgm.svcInfoMap[mgm.svcToElemMap[appInfo.app.Id]]
-		}
 	}
 
 	// For each net location in scenario, use Group LB algorithm to determine which
@@ -533,7 +593,7 @@ func refreshMgSvcMapping() {
 				// notification and update mapping
 				if bestApp != currentApp {
 					log.Info("Best App: " + bestApp + " != Current App: " + currentApp)
-					completeStateTransfer(mgInfo, netElemInfo, ueInfo, mgm.elemToSvcMap[currentApp])
+					completeStateTransfer(mgInfo, netElemInfo, ueInfo, currentApp)
 					setSvcMap(netElemInfo, mgInfo.mg.Name, bestApp)
 				}
 
@@ -557,7 +617,7 @@ func refreshMgSvcMapping() {
 				// notification and update mapping
 				if bestApp != currentApp {
 					log.Info("Best App: " + bestApp + " != Current App: " + currentApp)
-					completeStateTransfer(mgInfo, netElemInfo, ueInfo, mgm.elemToSvcMap[currentApp])
+					completeStateTransfer(mgInfo, netElemInfo, ueInfo, currentApp)
 					setSvcMap(netElemInfo, mgInfo.mg.Name, bestApp)
 				}
 
@@ -723,22 +783,12 @@ func applyMgSvcMapping() {
 		log.Error(err.Error())
 		return
 	}
-
-	// Send LB Rules Update message
-	msg := mgm.mqLocal.CreateMsg(mq.MsgMgLbRulesUpdate, moduleTcEngine, mgm.sandboxName)
-	log.Debug("TX MSG: ", mq.PrintMsg(msg))
-	err = mgm.mqLocal.SendMsg(msg)
-	if err != nil {
-		log.Error("Failed to send message. Error: ", err.Error())
-	}
 }
 
 func mgCreate(mg *mgModel.MobilityGroup) error {
 	// Make sure group does not already exist
 	if mgm.mgInfoMap[mg.Name] != nil {
-		log.Warn("Mobility group already exists: ", mg.Name)
-		err := errors.New("Mobility group already exists")
-		return err
+		return errors.New("Mobility group already exists")
 	}
 
 	// Create new Mobility Group & copy data
@@ -760,8 +810,8 @@ func mgUpdate(mg *mgModel.MobilityGroup) error {
 	// Make sure group exists
 	mgInfo := mgm.mgInfoMap[mg.Name]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mg.Name)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mg.Name)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -775,8 +825,8 @@ func mgUpdate(mg *mgModel.MobilityGroup) error {
 func mgDelete(mgName string) error {
 	// Make sure group exists
 	if mgm.mgInfoMap[mgName] == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -791,14 +841,20 @@ func mgAppCreate(mgName string, mgApp *mgModel.MobilityGroupApp) error {
 	// Make sure group exists
 	mgInfo := mgm.mgInfoMap[mgName]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 	// Make sure App does not already exist
 	if mgInfo.appInfoMap[mgApp.Id] != nil {
-		log.Error("Mobility group App already exists: ", mgApp.Id)
-		err := errors.New("Mobility group App already exists")
+		err := errors.New("Mobility group App already exists: " + mgApp.Id)
+		log.Error(err.Error())
+		return err
+	}
+	// Make sure App ID is equal to a service instance
+	if mgm.svcInfoMap[mgApp.Id] == nil {
+		err := errors.New("MG App ID not equal to service instance: " + mgApp.Id)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -819,6 +875,8 @@ func mgAppCreate(mgName string, mgApp *mgModel.MobilityGroupApp) error {
 	// Add to MG App map & App client map
 	mgInfo.appInfoMap[mgApp.Id] = mgAppInfo
 	log.Info("Created new MG App: " + mgApp.Id + " in group: " + mgName)
+
+	// Re-evaluate MG best app instance for each scenario network location
 	refreshNetLocAppMap(mgInfo)
 
 	// Re-evaluate MG Service mapping
@@ -834,15 +892,15 @@ func mgAppUpdate(mgName string, mgApp *mgModel.MobilityGroupApp) error {
 	// Make sure group exists
 	mgInfo := mgm.mgInfoMap[mgName]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 	// Make sure App exists
 	mgAppInfo := mgInfo.appInfoMap[mgApp.Id]
 	if mgAppInfo == nil {
-		log.Error("Mobility group App does not exist: ", mgApp.Id)
-		err := errors.New("Mobility group App does not exist")
+		err := errors.New("Mobility group App does not exist: " + mgApp.Id)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -854,8 +912,8 @@ func mgAppUpdate(mgName string, mgApp *mgModel.MobilityGroupApp) error {
 	mgAppClientCfg.BasePath = mgApp.Url
 	mgAppInfo.appClient = mga.NewAPIClient(mgAppClientCfg)
 	if mgAppInfo.appClient == nil {
-		log.Error("Failed to create MG App REST API client: ", mgAppClientCfg.BasePath)
-		err := errors.New("Failed to create MG App REST API client")
+		err := errors.New("Failed to create MG App REST API client: " + mgAppClientCfg.BasePath)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -867,20 +925,22 @@ func mgAppDelete(mgName string, appID string) error {
 	// Make sure group exists
 	mgInfo := mgm.mgInfoMap[mgName]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 	// Make sure App exists
 	if mgInfo.appInfoMap[appID] == nil {
-		log.Error("Mobility group App does not exist: ", appID)
-		err := errors.New("Mobility group App does not exist")
+		err := errors.New("Mobility group App does not exist: " + appID)
+		log.Error(err.Error())
 		return err
 	}
 
 	// Remove entry from App map & App Client map
 	delete(mgInfo.appInfoMap, appID)
 	log.Info("Deleted MG App: " + appID + " in group: " + mgName)
+
+	// Re-evaluate MG best app instance for each scenario network location
 	refreshNetLocAppMap(mgInfo)
 
 	return nil
@@ -890,14 +950,14 @@ func mgUeCreate(mgName string, appID string, mgUe *mgModel.MobilityGroupUe) erro
 	// Make sure group exists
 	mgInfo := mgm.mgInfoMap[mgName]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 	// Make sure App exists
 	if mgInfo.appInfoMap[appID] == nil {
-		log.Error("Mobility group App does not exist: ", appID)
-		err := errors.New("Mobility group App does not exist")
+		err := errors.New("Mobility group App does not exist: " + appID)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -925,23 +985,22 @@ func processAppState(mgName string, appID string, mgAppState *mgModel.MobilityGr
 	// Retrieve MG info
 	mgInfo := mgm.mgInfoMap[mgName]
 	if mgInfo == nil {
-		log.Error("Mobility group does not exist: ", mgName)
-		err := errors.New("Mobility group does not exist")
+		err := errors.New("Mobility group does not exist: " + mgName)
+		log.Error(err.Error())
 		return err
 	}
 	// Retrieve App info
 	appInfo := mgInfo.appInfoMap[appID]
-
 	if appInfo == nil {
-		log.Error("Mobility group App does not exist: ", appID)
-		err := errors.New("Mobility group App does not exist")
+		err := errors.New("Mobility group App does not exist: " + appID)
+		log.Error(err.Error())
 		return err
 	}
 	// Retrieve UE Info
 	ueInfo := mgInfo.ueInfoMap[mgAppState.UeId]
 	if ueInfo == nil {
-		log.Error("Mobility group UE does not exist: ", mgAppState.UeId)
-		err := errors.New("Mobility group UE does not exist")
+		err := errors.New("Mobility group UE does not exist: " + mgAppState.UeId)
+		log.Error(err.Error())
 		return err
 	}
 
@@ -955,8 +1014,6 @@ func processAppState(mgName string, appID string, mgAppState *mgModel.MobilityGr
 
 	mgm.mutex.Lock()
 	for appName := range ueInfo.appsInRange {
-		appName = mgm.elemToSvcMap[appName]
-
 		if appName != appID {
 			appInfo := mgInfo.appInfoMap[appName]
 			if appInfo == nil {
@@ -1431,14 +1488,6 @@ func mgTransferAppState(w http.ResponseWriter, r *http.Request) {
 // 		for k := range mgSvcInfo.services {
 // 			log.Debug("         " + k)
 // 		}
-// 	}
-// 	log.Debug("+++ svcToElemMap:")
-// 	for k, v := range mgm.svcToElemMap {
-// 		log.Debug("   " + k + ":" + v)
-// 	}
-// 	log.Debug("+++ elemToSvcMap:")
-// 	for k, v := range mgm.elemToSvcMap {
-// 		log.Debug("   " + k + ":" + v)
 // 	}
 // 	log.Debug("+++ netElemInfoMap:")
 // 	for netElemName, netElemInfo := range mgm.netElemInfoMap {

--- a/go-apps/meep-mg-manager/server/mg-manager.go
+++ b/go-apps/meep-mg-manager/server/mg-manager.go
@@ -151,7 +151,6 @@ type MgManager struct {
 	netLocList   []string
 	svcInfoMap   map[string]*serviceInfo
 	mgSvcInfoMap map[string]*mgServiceInfo
-	mgList       map[string]bool
 
 	// Network Element Info mapping
 	netElemInfoMap map[string]*netElemInfo
@@ -168,7 +167,6 @@ func Init() (err error) {
 	mgm.netLocList = make([]string, 0)
 	mgm.svcInfoMap = make(map[string]*serviceInfo)
 	mgm.mgSvcInfoMap = make(map[string]*mgServiceInfo)
-	mgm.mgList = make(map[string]bool)
 	mgm.netElemInfoMap = make(map[string]*netElemInfo)
 	mgm.mgInfoMap = make(map[string]*mgInfo)
 
@@ -344,7 +342,6 @@ func clearScenario() {
 	mgm.netLocList = make([]string, 0)
 	mgm.svcInfoMap = make(map[string]*serviceInfo)
 	mgm.mgSvcInfoMap = make(map[string]*mgServiceInfo)
-	mgm.mgList = make(map[string]bool)
 	mgm.netElemInfoMap = make(map[string]*netElemInfo)
 	mgm.mgInfoMap = make(map[string]*mgInfo)
 
@@ -370,7 +367,6 @@ func processScenario(model *mod.Model) error {
 	// Reset service info maps
 	mgm.svcInfoMap = make(map[string]*serviceInfo)
 	mgm.mgSvcInfoMap = make(map[string]*mgServiceInfo)
-	mgm.mgList = make(map[string]bool)
 
 	// Populate net location list
 	mgm.netLocList = model.GetNodeNames(mod.NodeTypePoa, mod.NodeTypePoa4G, mod.NodeTypePoa5G, mod.NodeTypePoaWifi)
@@ -461,7 +457,7 @@ func processScenario(model *mod.Model) error {
 
 	// Remove stale Mobility Groups
 	for mgName, mgInfo := range mgm.mgInfoMap {
-		if _, found := mgm.mgList[mgName]; !found {
+		if _, found := mgm.mgSvcInfoMap[mgName]; !found {
 			log.Debug("Removing stale MG: ", mgName)
 			delete(mgm.mgInfoMap, mgName)
 		} else {
@@ -518,9 +514,6 @@ func addServiceInfo(svcName string, mgSvcName string, nodeName string) {
 		mg.SessionTransferMode = sessionTransModeForced
 		mg.LoadBalancingAlgorithm = lbAlgoHopCount
 		_ = mgCreate(&mg)
-
-		// Add MG to list
-		mgm.mgList[mg.Name] = true
 	}
 
 	// Add service instance to service info map

--- a/go-apps/meep-tc-engine/routing-engine.go
+++ b/go-apps/meep-tc-engine/routing-engine.go
@@ -96,6 +96,8 @@ func (re *RoutingEngine) RefreshLbRules() {
 		for _, svcMap := range netElem.ServiceMaps {
 			if svcInfo, found := svcInfoMap[svcMap.LbSvcName]; found {
 				podInfo.MgSvcMap[svcMap.MgSvcName] = svcInfo
+			} else {
+				log.Error("failed to find service instance: ", svcMap.LbSvcName)
 			}
 		}
 	}

--- a/go-apps/meep-tc-engine/routing-engine.go
+++ b/go-apps/meep-tc-engine/routing-engine.go
@@ -32,6 +32,17 @@ const typeMeSvc string = "ME-SVC"
 const typeIngressSvc string = "INGRESS-SVC"
 const typeEgressSvc string = "EGRESS-SVC"
 
+const fieldSvcType string = "svc-type"
+const fieldSvcName string = "svc-name"
+const fieldSvcIp string = "svc-ip"
+const fieldSvcProtocol string = "svc-protocol"
+const fieldSvcPort string = "svc-port"
+const fieldLbSvcName string = "lb-svc-name"
+const fieldLbSvcIp string = "lb-svc-ip"
+const fieldLbSvcPort string = "lb-svc-port"
+const fieldLbPodName string = "lb-pod-name"
+const fieldLbPodIp string = "lb-pod-ip"
+
 const DEFAULT_LB_RULES_DB = 0
 
 // LbRulesStore -
@@ -143,6 +154,8 @@ func (re *RoutingEngine) applyLbRules() {
 				fields[fieldLbSvcName] = svcInfo.Name
 				fields[fieldLbSvcIp] = tce.ipManager.GetSvcIp(svcInfo.Name)
 				fields[fieldLbSvcPort] = portInfo.Port
+				fields[fieldLbPodName] = svcInfo.Node
+				fields[fieldLbPodIp] = tce.ipManager.GetPodIp(svcInfo.Node)
 
 				// Make unique key
 				key := tce.netCharStore.baseKey + typeLb + ":" + podInfo.Name + ":" +
@@ -178,6 +191,8 @@ func (re *RoutingEngine) applyLbRules() {
 			fields[fieldLbSvcName] = svcInfo.Name
 			fields[fieldLbSvcIp] = tce.ipManager.GetSvcIp(svcInfo.Name)
 			fields[fieldLbSvcPort] = svcMap.SvcPort
+			fields[fieldLbPodName] = svcInfo.Node
+			fields[fieldLbPodIp] = tce.ipManager.GetPodIp(svcInfo.Node)
 
 			// Make unique key
 			key := tce.netCharStore.baseKey + typeLb + ":" + podInfo.Name + ":" +
@@ -200,6 +215,8 @@ func (re *RoutingEngine) applyLbRules() {
 			fields[fieldLbSvcName] = svcMap.SvcName
 			fields[fieldLbSvcIp] = svcMap.SvcIp
 			fields[fieldLbSvcPort] = svcMap.SvcPort
+			fields[fieldLbPodName] = "n/a"
+			fields[fieldLbPodIp] = IP_ADDR_NONE
 
 			// Make unique key
 			key := tce.netCharStore.baseKey + typeLb + ":" + podInfo.Name + ":" +

--- a/go-apps/meep-tc-engine/tc-engine.go
+++ b/go-apps/meep-tc-engine/tc-engine.go
@@ -40,15 +40,6 @@ const tcEngineKey string = "tc-engine:"
 const mgManagerKey string = "mg-manager:"
 const typeNet string = "net"
 
-const fieldSvcType string = "svc-type"
-const fieldSvcName string = "svc-name"
-const fieldSvcIp string = "svc-ip"
-const fieldSvcProtocol string = "svc-protocol"
-const fieldSvcPort string = "svc-port"
-const fieldLbSvcName string = "lb-svc-name"
-const fieldLbSvcIp string = "lb-svc-ip"
-const fieldLbSvcPort string = "lb-svc-port"
-
 // MQ payload fields
 const fieldEventType = "event-type"
 

--- a/go-apps/meep-tc-sidecar/destination.go
+++ b/go-apps/meep-tc-sidecar/destination.go
@@ -150,7 +150,7 @@ func (u *destination) compute() (st stat) {
 	return
 }
 
-func (u *destination) processRxTx(ifbStatsStr string) float64 {
+func (u *destination) processRxTx(ifbStatsStr string, curTime time.Time) float64 {
 
 	// Retrieve ifb statistics from passed string
 	// NOTE: we have to read the ifbStats from the back since based on the results are always at
@@ -163,9 +163,6 @@ func (u *destination) processRxTx(ifbStatsStr string) float64 {
 	} else {
 		log.Error("Error in the ifb statistics output: ", ifbStats)
 	}
-
-	// Get timestamp for calculations
-	curTime := time.Now()
 
 	// Calculate throughput in Mbps
 	var tput float64
@@ -182,7 +179,7 @@ func (u *destination) processRxTx(ifbStatsStr string) float64 {
 	return tput
 }
 
-func (u *destination) logRxTx(ifbStatsStr string) {
+func (u *destination) logRxTx(ifbStatsStr string, curTime time.Time) {
 
 	// Retrieve ifb statistics from passed string
 	// NOTE: we have to read the ifbStats from the back since based on the results are always at
@@ -198,9 +195,6 @@ func (u *destination) logRxTx(ifbStatsStr string) {
 	} else {
 		log.Error("Error in the ifb statistics output: ", ifbStats)
 	}
-
-	// Get timestamp for calculations
-	curTime := time.Now()
 
 	// Calculate packet loss percentage
 	var loss float64

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -70,8 +70,11 @@ const fieldSvcName string = "svc-name"
 const fieldSvcIp string = "svc-ip"
 const fieldSvcProtocol string = "svc-protocol"
 const fieldSvcPort string = "svc-port"
+const fieldLbSvcName string = "lb-svc-name"
 const fieldLbSvcIp string = "lb-svc-ip"
 const fieldLbSvcPort string = "lb-svc-port"
+const fieldLbPodName string = "lb-pod-name"
+const fieldLbPodIp string = "lb-pod-ip"
 
 const DEFAULT_SIDECAR_DB = 0
 
@@ -509,8 +512,17 @@ func refreshLbRulesHandler(key string, fields map[string]string, userData interf
 		"-m", "comment", "--comment", service)
 
 	// Ignore rules with missing IP addresses
-	if fields[fieldSvcIp] == ipAddrNone || fields[fieldLbSvcIp] == ipAddrNone {
-		log.Debug("Missing IP address for service: ", service)
+	if fields[fieldSvcIp] == ipAddrNone {
+		log.Debug("Missing MG Svc IP address for service: ", service)
+		return nil
+	}
+	if fields[fieldLbSvcIp] == ipAddrNone {
+		log.Debug("Missing LB Svc IP address for service: ", fields[fieldLbSvcName])
+		return nil
+	}
+	// For ME Svc & Ingress rules, verify LB pod IP as well
+	if (fields[fieldSvcType] == typeMeSvc || fields[fieldSvcType] == typeIngressSvc) && fields[fieldLbPodIp] == ipAddrNone {
+		log.Debug("Missing LB Pod IP address for pod: ", fields[fieldLbPodName])
 		return nil
 	}
 

--- a/go-apps/meep-tc-sidecar/main.go
+++ b/go-apps/meep-tc-sidecar/main.go
@@ -680,6 +680,10 @@ func workRxTxPackets() {
 			semOptsDests.Unlock()
 			return
 		}
+
+		// Get timestamp for calculations
+		curTime := time.Now()
+
 		//split line by line
 		lineStrings := strings.Split(out, "\n")
 
@@ -706,7 +710,7 @@ func workRxTxPackets() {
 
 		// Get throughput metrics for each dest
 		for _, dest := range opts.dests {
-			tputStats[dest.remoteName] = dest.processRxTx(qdiscResults["ifb"+dest.ifbNumber])
+			tputStats[dest.remoteName] = dest.processRxTx(qdiscResults["ifb"+dest.ifbNumber], curTime)
 		}
 
 		key := metricsBaseKey + PodName + ":throughput"
@@ -733,6 +737,10 @@ func workLogRxTxData() {
 			semOptsDests.Unlock()
 			return
 		}
+
+		// Get timestamp for calculations
+		curTime := time.Now()
+
 		//split line by line
 		lineStrings := strings.Split(out, "\n")
 
@@ -756,7 +764,7 @@ func workLogRxTxData() {
 
 		// Get NC metrics for each dest
 		for _, dest := range opts.dests {
-			dest.logRxTx(qdiscResults["ifb"+dest.ifbNumber])
+			dest.logRxTx(qdiscResults["ifb"+dest.ifbNumber], curTime)
 		}
 		semOptsDests.Unlock()
 


### PR DESCRIPTION
**CHANGES:**
- meep-model package:
  - New method to update POAs in range (previously in Sandbox Controller)
- TC Engine:
  - Include Pod IP in LB rule updates to help sidecar determine when to apply the rules
- TC Sidecar:
  - Throughput calculation improvement (timestamp now taken immediately after retrieving metrics)
  - LB rules check for valid IP address before applying rules
- MG Manager:
  - Remove unused maps
  - Added message-specific handlers (activate, update, terminate scenario)
  - Code updates to remove stale Mobility Groups, MG Apps & UEs
  - New validation checks: 
    - MG App name must be equal to a service instance name in active scenario
    - UE ID must be equal to a UE name in active scenario
  - LB hop count algorithm update to stay on current edge app if hop count is equal

**TESTING:**
- UT, System & Cypress tests pass
- Manual verification of Add/Remove Edge Applications with Multi-Edge services

**KNOWN LIMITATIONS:**
- App state transfer not supported if the MG App instance serving the UE is removed
  - The state cannot be retrieved from the removed MG app instance and therefore cannot be transferred
- App state transfer not supported if the new MG app instance is used immediately
  - The state is passed to the MG Manager, however the MG Manager currently does not store the state if the target app is not immediately reachable
  - NOTE: if the new MG App instance has enough time to start before the app state transfer then it will be successful

