### PR TITLE
Prometheus Chart fixes + Increased PV size & retention period

### DIFF
--- a/charts/kube-prometheus-stack/templates/prometheus/pvc-deleter.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/pvc-deleter.yaml
@@ -51,16 +51,16 @@ spec:
       containers:
       - name: post-delete-job
         image: "bitnami/kubectl"
-        command: ["kubectl"]
+        command: ["/bin/sh", "-c"]
         args:
-        - "delete"
-        - "pvc"
+        - kubectl delete pvc
         {{- if and $prometheus $promStorageSpec }}
-        - "{{ $promStorageSpec.volumeClaimTemplate.metadata.name }}-prometheus-{{ template "kube-prometheus-stack.fullname" . }}-server-0"
+          {{ $promStorageSpec.volumeClaimTemplate.metadata.name }}-prometheus-{{ template "kube-prometheus-stack.fullname" . }}-server-0
         {{- end }}
         {{- if and $alertmanager $alertStorageSpec }}
-        - "{{ $alertStorageSpec.volumeClaimTemplate.metadata.name }}-alertmanager-{{ template "kube-prometheus-stack.fullname" . }}-alertmanager-0"
+          {{ $alertStorageSpec.volumeClaimTemplate.metadata.name }}-alertmanager-{{ template "kube-prometheus-stack.fullname" . }}-alertmanager-0
         {{- end }}
+          ; echo done;
       serviceAccountName: pvc-deleter-sa
       securityContext:
         runAsUser: 0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -143,23 +143,23 @@ alertmanager:
   ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
   ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
   ##
-  config:
-    global:
-      resolve_timeout: 5m
-    route:
-      group_by: ['job']
-      group_wait: 30s
-      group_interval: 5m
-      repeat_interval: 12h
-      receiver: 'null'
-      routes:
-      - match:
-          alertname: Watchdog
-        receiver: 'null'
-    receivers:
-    - name: 'null'
-    templates:
-    - '/etc/alertmanager/config/*.tmpl'
+  # config:
+  #   global:
+  #     resolve_timeout: 5m
+  #   route:
+  #     group_by: ['job']
+  #     group_wait: 30s
+  #     group_interval: 5m
+  #     repeat_interval: 12h
+  #     receiver: 'null'
+  #     routes:
+  #     - match:
+  #         alertname: Watchdog
+  #       receiver: 'null'
+  #   receivers:
+  #   - name: 'null'
+  #   templates:
+  #   - '/etc/alertmanager/config/*.tmpl'
 
   ## Pass the Alertmanager configuration directives through Helm's templating
   ## engine. If the Alertmanager configuration contains Alertmanager templates,

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -196,7 +196,7 @@ alertmanager:
   #       {{ end }}
 
   ingress:
-    enabled: true
+    enabled: false
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
@@ -1800,7 +1800,7 @@ prometheus:
 
     ## How long to retain metrics
     ##
-    retention: 30d
+    retention: 100d
 
     ## Maximum size of metrics
     ##
@@ -1912,7 +1912,7 @@ prometheus:
           storageClassName: meep-prometheus-server
           resources:
             requests:
-              storage: 10Gi
+              storage: 17Gi
           selector:
             matchLabels:
               app: prometheus-server
@@ -1921,7 +1921,7 @@ prometheus:
       enabled: true
       accessModes:
         - ReadWriteOnce
-      size: 10Gi
+      size: 17Gi
       reclaimPolicy: Retain
       location: "<WORKDIR>/prometheus/server"
 


### PR DESCRIPTION
**CHANGES:**
- Prometheus chart:
  - Updated PVC deleter job to always return success (avoids hanging the helm chart uninstall)
  - Removed unused alert manager config
  - Disabled Alert Manager ingress by default
  - Increased Prometheus retention period from 30d to 100d
  - Increased Prometheus PV size from 10Gi to 17Gi

**TESTING:**
- UT & Cypress tests pass
- Manual testing of deploying & removing Prometheus