### PR TITLE
MEC-256 Alertmanager fix for permission error with PV subpath

### DIFF
--- a/charts/kube-prometheus-stack/templates/alertmanager/persistentvolume.yaml
+++ b/charts/kube-prometheus-stack/templates/alertmanager/persistentvolume.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.alertmanager.alertmanagerSpec.persistentVolume.enabled }}
+{{- if and .Values.alertmanager.enabled .Values.alertmanager.alertmanagerSpec.persistentVolume.enabled }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:

--- a/charts/kube-prometheus-stack/templates/prometheus/persistentvolume.yaml
+++ b/charts/kube-prometheus-stack/templates/prometheus/persistentvolume.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.prometheusSpec.persistentVolume.enabled }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.prometheusSpec.persistentVolume.enabled }}
 kind: PersistentVolume
 apiVersion: v1
 metadata:

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -152,6 +152,8 @@ func deployEnsureStorage(cobraCmd *cobra.Command) {
 
 	// Local storage structure
 	cmd := exec.Command("mkdir", "-p", deployData.workdir)
+	cmd.Args = append(cmd.Args, deployData.workdir+"/user")
+	cmd.Args = append(cmd.Args, deployData.workdir+"/user/values")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/certs")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/couchdb")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/docker-registry")
@@ -166,6 +168,7 @@ func deployEnsureStorage(cobraCmd *cobra.Command) {
 	cmd.Args = append(cmd.Args, deployData.workdir+"/prometheus/server")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/prometheus/server/prometheus-db")
 	cmd.Args = append(cmd.Args, deployData.workdir+"/prometheus/alertmanager")
+	cmd.Args = append(cmd.Args, deployData.workdir+"/prometheus/alertmanager/alertmanager-db")
 	_, err := utils.ExecuteCmd(cmd, cobraCmd)
 	if err != nil {
 		err = errors.New("Error creating path [" + deployData.workdir + "]")


### PR DESCRIPTION
**CHANGES:**
- Prometheus helm chart update to deploy Alert Manager only if enabled
- _meepctl_ fix to create necessary PV host paths for Alert Manager