### PR TITLE
Sandbox Metrics + GIS Engine fixes

### DIFF
--- a/charts/grafana/dashboards/platform-advantedge.json
+++ b/charts/grafana/dashboards/platform-advantedge.json
@@ -15,7 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1613495656791,
+  "id": 17,
+  "iteration": 1618533539997,
   "links": [],
   "panels": [
     {
@@ -26,6 +27,270 @@
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 91,
+      "panels": [],
+      "title": "Sandbox Metrics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "meep-influxdb",
+      "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "displayName": "Sbox Creation Time",
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 7,
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 93,
+      "interval": "",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.5",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT createtime FROM global_sandbox_metrics.autogen.sbox WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Sandbox Creation Time",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 10,
+        "y": 1
+      },
+      "id": 95,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "expr": "sum(increase(mon_engine_sbox_create_duration_sum[$__range])) / sum(increase(mon_engine_sbox_create_duration_count[$__range]))",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Average Sandbox Creation Time",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "light-green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 14,
+        "y": 1
+      },
+      "id": 97,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.5",
+      "targets": [
+        {
+          "expr": "sum by (le) (increase(mon_engine_sbox_create_duration_bucket[$__range]))",
+          "format": "heatmap",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sandbox Creation Time Distribution (seconds)",
+      "transformations": [],
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
       },
       "id": 37,
       "panels": [],
@@ -44,7 +309,7 @@
         "h": 1,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 9
       },
       "id": 78,
       "options": {
@@ -69,7 +334,7 @@
         "h": 1,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 9
       },
       "id": 79,
       "options": {
@@ -106,7 +371,7 @@
         "h": 5,
         "w": 4,
         "x": 0,
-        "y": 2
+        "y": 10
       },
       "id": 55,
       "options": {
@@ -167,7 +432,7 @@
         "h": 5,
         "w": 8,
         "x": 4,
-        "y": 2
+        "y": 10
       },
       "id": 77,
       "options": {
@@ -242,7 +507,7 @@
         "h": 5,
         "w": 4,
         "x": 12,
-        "y": 2
+        "y": 10
       },
       "id": 85,
       "options": {
@@ -303,7 +568,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 2
+        "y": 10
       },
       "id": 86,
       "options": {
@@ -385,7 +650,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 15
       },
       "id": 30,
       "options": {
@@ -473,7 +738,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 15
       },
       "id": 87,
       "options": {
@@ -532,7 +797,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 24
       },
       "id": 33,
       "options": {
@@ -591,7 +856,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 24
       },
       "id": 88,
       "options": {
@@ -655,7 +920,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 30
       },
       "id": 38,
       "options": {
@@ -719,7 +984,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 30
       },
       "id": 89,
       "options": {
@@ -813,5 +1078,5 @@
   "timezone": "",
   "title": "Platform (AdvantEDGE)",
   "uid": "platform-advantedge",
-  "version": 1
+  "version": 2
 }

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -526,6 +526,8 @@ grafana.ini:
     org_role: Viewer
   security:
     allow_embedding: true
+  dashboards:
+    min_refresh_interval: 1s
  # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
  # auth.github:
  #    enabled: false

--- a/go-apps/meep-gis-engine/server/gis-automation.go
+++ b/go-apps/meep-gis-engine/server/gis-automation.go
@@ -60,6 +60,9 @@ func resetAutomation() {
 }
 
 func setAutomation(automationType string, state bool) (err error) {
+	ge.mutex.Lock()
+	defer ge.mutex.Unlock()
+
 	// Validate automation type
 	if _, found := ge.automation[automationType]; !found {
 		return errors.New("Automation type not found")

--- a/go-apps/meep-gis-engine/server/gis-engine.go
+++ b/go-apps/meep-gis-engine/server/gis-engine.go
@@ -44,7 +44,7 @@ const postgisUser = "postgres"
 const postgisPwd = "pwd"
 
 // Enable profiling
-const profiling = true
+const profiling = false
 
 var proStart time.Time
 var proFinish time.Time

--- a/go-apps/meep-gis-engine/server/gis-engine.go
+++ b/go-apps/meep-gis-engine/server/gis-engine.go
@@ -44,7 +44,7 @@ const postgisUser = "postgres"
 const postgisPwd = "pwd"
 
 // Enable profiling
-const profiling = false
+const profiling = true
 
 var proStart time.Time
 var proFinish time.Time

--- a/go-packages/meep-gis-asset-mgr/asset-mgr.go
+++ b/go-packages/meep-gis-asset-mgr/asset-mgr.go
@@ -40,10 +40,9 @@ const (
 )
 
 // Enable profiling
-const profiling = false
+const profiling = true
 
-var proStart time.Time
-var proFinish time.Time
+var profilingTimers map[string]time.Time
 
 const (
 	FieldPosition  = "position"
@@ -147,6 +146,13 @@ type AssetMgr struct {
 	db        *sql.DB
 	connected bool
 	updateCb  func(string, string)
+}
+
+// Profiling init
+func init() {
+	if profiling {
+		profilingTimers = make(map[string]time.Time)
+	}
 }
 
 // NewAssetMgr - Creates and initializes a new GIS Asset Manager
@@ -408,7 +414,7 @@ func (am *AssetMgr) DeleteTable(tableName string) (err error) {
 // CreateUe - Create new UE
 func (am *AssetMgr) CreateUe(id string, name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["CreateUe"] = time.Now()
 	}
 
 	var position string
@@ -511,8 +517,8 @@ func (am *AssetMgr) CreateUe(id string, name string, data map[string]interface{}
 	am.notifyListener(TypeUe, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("CreateUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("CreateUe: ", now.Sub(profilingTimers["CreateUe"]))
 	}
 	return nil
 }
@@ -520,7 +526,7 @@ func (am *AssetMgr) CreateUe(id string, name string, data map[string]interface{}
 // CreatePoa - Create new POA
 func (am *AssetMgr) CreatePoa(id string, name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["CreatePoa"] = time.Now()
 	}
 
 	var subtype string
@@ -582,8 +588,8 @@ func (am *AssetMgr) CreatePoa(id string, name string, data map[string]interface{
 	am.notifyListener(TypePoa, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("CreatePoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("CreatePoa: ", now.Sub(profilingTimers["CreatePoa"]))
 	}
 	return nil
 }
@@ -591,7 +597,7 @@ func (am *AssetMgr) CreatePoa(id string, name string, data map[string]interface{
 // CreateCompute - Create new Compute
 func (am *AssetMgr) CreateCompute(id string, name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["CreateCompute"] = time.Now()
 	}
 
 	var subtype string
@@ -645,8 +651,8 @@ func (am *AssetMgr) CreateCompute(id string, name string, data map[string]interf
 	am.notifyListener(TypeCompute, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("CreateCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("CreateCompute: ", now.Sub(profilingTimers["CreateCompute"]))
 	}
 	return nil
 }
@@ -654,7 +660,7 @@ func (am *AssetMgr) CreateCompute(id string, name string, data map[string]interf
 // UpdateUe - Update existing UE
 func (am *AssetMgr) UpdateUe(name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["UpdateUe"] = time.Now()
 	}
 
 	// Validate input
@@ -780,8 +786,8 @@ func (am *AssetMgr) UpdateUe(name string, data map[string]interface{}) (err erro
 	am.notifyListener(TypeUe, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("UpdateUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("UpdateUe: ", now.Sub(profilingTimers["UpdateUe"]))
 	}
 	return nil
 }
@@ -789,7 +795,7 @@ func (am *AssetMgr) UpdateUe(name string, data map[string]interface{}) (err erro
 // UpdatePoa - Update existing POA
 func (am *AssetMgr) UpdatePoa(name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["UpdatePoa"] = time.Now()
 	}
 
 	// Validate input
@@ -841,8 +847,8 @@ func (am *AssetMgr) UpdatePoa(name string, data map[string]interface{}) (err err
 	am.notifyListener(TypePoa, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("UpdatePoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("UpdatePoa: ", now.Sub(profilingTimers["UpdatePoa"]))
 	}
 	return nil
 }
@@ -850,7 +856,7 @@ func (am *AssetMgr) UpdatePoa(name string, data map[string]interface{}) (err err
 // UpdateCompute - Update existing Compute
 func (am *AssetMgr) UpdateCompute(name string, data map[string]interface{}) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["UpdateCompute"] = time.Now()
 	}
 
 	// Validate input
@@ -901,8 +907,8 @@ func (am *AssetMgr) UpdateCompute(name string, data map[string]interface{}) (err
 	am.notifyListener(TypeCompute, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("UpdateCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("UpdateCompute: ", now.Sub(profilingTimers["UpdateCompute"]))
 	}
 	return nil
 }
@@ -910,7 +916,7 @@ func (am *AssetMgr) UpdateCompute(name string, data map[string]interface{}) (err
 // GetUe - Get UE information
 func (am *AssetMgr) GetUe(name string) (ue *Ue, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetUe"] = time.Now()
 	}
 
 	// Validate input
@@ -979,8 +985,8 @@ func (am *AssetMgr) GetUe(name string) (ue *Ue, err error) {
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetUe: ", now.Sub(profilingTimers["GetUe"]))
 	}
 	return ue, nil
 }
@@ -988,7 +994,7 @@ func (am *AssetMgr) GetUe(name string) (ue *Ue, err error) {
 // GetPoa - Get POA information
 func (am *AssetMgr) GetPoa(name string) (poa *Poa, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetPoa"] = time.Now()
 	}
 
 	// Validate input
@@ -1030,8 +1036,8 @@ func (am *AssetMgr) GetPoa(name string) (poa *Poa, err error) {
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetPoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetPoa: ", now.Sub(profilingTimers["GetPoa"]))
 	}
 	return poa, nil
 }
@@ -1039,7 +1045,7 @@ func (am *AssetMgr) GetPoa(name string) (poa *Poa, err error) {
 // GetCompute - Get Compute information
 func (am *AssetMgr) GetCompute(name string) (compute *Compute, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetCompute"] = time.Now()
 	}
 
 	// Validate input
@@ -1081,8 +1087,8 @@ func (am *AssetMgr) GetCompute(name string) (compute *Compute, err error) {
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetCompute: ", now.Sub(profilingTimers["GetCompute"]))
 	}
 	return compute, nil
 }
@@ -1090,7 +1096,7 @@ func (am *AssetMgr) GetCompute(name string) (compute *Compute, err error) {
 // GetAllUe - Get All UE information
 func (am *AssetMgr) GetAllUe() (ueMap map[string]*Ue, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetAllUe"] = time.Now()
 	}
 
 	// Create UE map
@@ -1151,8 +1157,8 @@ func (am *AssetMgr) GetAllUe() (ueMap map[string]*Ue, err error) {
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetAllUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetAllUe: ", now.Sub(profilingTimers["GetAllUe"]))
 	}
 	return ueMap, nil
 }
@@ -1160,7 +1166,7 @@ func (am *AssetMgr) GetAllUe() (ueMap map[string]*Ue, err error) {
 // GetAllPoa - Get all POA information
 func (am *AssetMgr) GetAllPoa() (poaMap map[string]*Poa, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetAllPoa"] = time.Now()
 	}
 
 	// Create POA map
@@ -1197,8 +1203,8 @@ func (am *AssetMgr) GetAllPoa() (poaMap map[string]*Poa, err error) {
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetAllPoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetAllPoa: ", now.Sub(profilingTimers["GetAllPoa"]))
 	}
 	return poaMap, nil
 }
@@ -1206,7 +1212,7 @@ func (am *AssetMgr) GetAllPoa() (poaMap map[string]*Poa, err error) {
 // GetAllCompute - Get all Compute information
 func (am *AssetMgr) GetAllCompute() (computeMap map[string]*Compute, err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["GetAllCompute"] = time.Now()
 	}
 
 	// Create Compute map
@@ -1243,8 +1249,8 @@ func (am *AssetMgr) GetAllCompute() (computeMap map[string]*Compute, err error) 
 	}
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("GetAllCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("GetAllCompute: ", now.Sub(profilingTimers["GetAllCompute"]))
 	}
 	return computeMap, nil
 }
@@ -1252,7 +1258,7 @@ func (am *AssetMgr) GetAllCompute() (computeMap map[string]*Compute, err error) 
 // DeleteUe - Delete UE entry
 func (am *AssetMgr) DeleteUe(name string) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeleteUe"] = time.Now()
 	}
 
 	// Validate input
@@ -1271,8 +1277,8 @@ func (am *AssetMgr) DeleteUe(name string) (err error) {
 	am.notifyListener(TypeUe, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeleteUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeleteUe: ", now.Sub(profilingTimers["DeleteUe"]))
 	}
 	return nil
 }
@@ -1280,7 +1286,7 @@ func (am *AssetMgr) DeleteUe(name string) (err error) {
 // DeletePoa - Delete POA entry
 func (am *AssetMgr) DeletePoa(name string) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeletePoa"] = time.Now()
 	}
 
 	// Validate input
@@ -1307,8 +1313,8 @@ func (am *AssetMgr) DeletePoa(name string) (err error) {
 	am.notifyListener(TypePoa, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeletePoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeletePoa: ", now.Sub(profilingTimers["DeletePoa"]))
 	}
 	return nil
 }
@@ -1316,7 +1322,7 @@ func (am *AssetMgr) DeletePoa(name string) (err error) {
 // DeleteCompute - Delete Compute entry
 func (am *AssetMgr) DeleteCompute(name string) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeleteCompute"] = time.Now()
 	}
 
 	// Validate input
@@ -1335,8 +1341,8 @@ func (am *AssetMgr) DeleteCompute(name string) (err error) {
 	am.notifyListener(TypeCompute, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeleteCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeleteCompute: ", now.Sub(profilingTimers["DeleteCompute"]))
 	}
 	return nil
 }
@@ -1344,7 +1350,7 @@ func (am *AssetMgr) DeleteCompute(name string) (err error) {
 // DeleteAllUe - Delete all UE entries
 func (am *AssetMgr) DeleteAllUe() (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeleteAllUe"] = time.Now()
 	}
 
 	// !!! IMPORTANT NOTE !!!
@@ -1365,8 +1371,8 @@ func (am *AssetMgr) DeleteAllUe() (err error) {
 	am.notifyListener(TypeUe, "")
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeleteAllUe: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeleteAllUe: ", now.Sub(profilingTimers["DeleteAllUe"]))
 	}
 	return nil
 }
@@ -1374,7 +1380,7 @@ func (am *AssetMgr) DeleteAllUe() (err error) {
 // DeleteAllPoa - Delete all POA entries
 func (am *AssetMgr) DeleteAllPoa() (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeleteAllPoa"] = time.Now()
 	}
 
 	_, err = am.db.Exec(`DELETE FROM ` + PoaTable)
@@ -1395,8 +1401,8 @@ func (am *AssetMgr) DeleteAllPoa() (err error) {
 	am.notifyListener(TypePoa, AllAssets)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeleteAllPoa: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeleteAllPoa: ", now.Sub(profilingTimers["DeleteAllPoa"]))
 	}
 	return nil
 }
@@ -1404,7 +1410,7 @@ func (am *AssetMgr) DeleteAllPoa() (err error) {
 // DeleteAllCompute - Delete all Compute entries
 func (am *AssetMgr) DeleteAllCompute() (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["DeleteAllCompute"] = time.Now()
 	}
 
 	_, err = am.db.Exec(`DELETE FROM ` + ComputeTable)
@@ -1417,8 +1423,8 @@ func (am *AssetMgr) DeleteAllCompute() (err error) {
 	am.notifyListener(TypeCompute, AllAssets)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("DeleteAllCompute: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("DeleteAllCompute: ", now.Sub(profilingTimers["DeleteAllCompute"]))
 	}
 	return nil
 }
@@ -1426,7 +1432,7 @@ func (am *AssetMgr) DeleteAllCompute() (err error) {
 // AdvanceUePosition - Advance UE along path by provided number of increments
 func (am *AssetMgr) AdvanceUePosition(name string, increment float32) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["AdvanceUePosition"] = time.Now()
 	}
 
 	// Set new position
@@ -1462,8 +1468,8 @@ func (am *AssetMgr) AdvanceUePosition(name string, increment float32) (err error
 	am.notifyListener(TypeUe, name)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("AdvanceUePosition: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("AdvanceUePosition: ", now.Sub(profilingTimers["AdvanceUePosition"]))
 	}
 	return nil
 }
@@ -1471,7 +1477,7 @@ func (am *AssetMgr) AdvanceUePosition(name string, increment float32) (err error
 // AdvanceAllUePosition - Advance all UEs along path by provided number of increments
 func (am *AssetMgr) AdvanceAllUePosition(increment float32) (err error) {
 	if profiling {
-		proStart = time.Now()
+		profilingTimers["AdvanceAllUePosition"] = time.Now()
 	}
 
 	// Set new position
@@ -1517,8 +1523,8 @@ func (am *AssetMgr) AdvanceAllUePosition(increment float32) (err error) {
 	am.notifyListener(TypeUe, AllAssets)
 
 	if profiling {
-		proFinish = time.Now()
-		log.Debug("AdvanceAllUePosition: ", proFinish.Sub(proStart))
+		now := time.Now()
+		log.Debug("AdvanceAllUePosition: ", now.Sub(profilingTimers["AdvanceAllUePosition"]))
 	}
 	return nil
 }
@@ -1527,6 +1533,10 @@ func (am *AssetMgr) AdvanceAllUePosition(increment float32) (err error) {
 
 // Recalculate UE path length & increment
 func (am *AssetMgr) refreshUePath(name string) (err error) {
+	if profiling {
+		profilingTimers["refreshUePath"] = time.Now()
+	}
+
 	query := `UPDATE ` + UeTable + `
 		SET path_length = ST_Length(path::geography),
 			path_increment = path_velocity / ST_Length(path::geography),
@@ -1537,11 +1547,19 @@ func (am *AssetMgr) refreshUePath(name string) (err error) {
 		log.Error(err.Error())
 		return err
 	}
+
+	if profiling {
+		now := time.Now()
+		log.Debug("- refreshUePath: ", now.Sub(profilingTimers["refreshUePath"]))
+	}
 	return nil
 }
 
 // Recalculate nearest POA & POAs in range for provided UE
 func (am *AssetMgr) refreshUe(name string) (err error) {
+	if profiling {
+		profilingTimers["refreshUe"] = time.Now()
+	}
 
 	// Initialize UE information map
 	ueMap := make(map[string]*Ue)
@@ -1566,11 +1584,19 @@ func (am *AssetMgr) refreshUe(name string) (err error) {
 	if err != nil {
 		return err
 	}
+
+	if profiling {
+		now := time.Now()
+		log.Debug("- refreshUe: ", now.Sub(profilingTimers["refreshUe"]))
+	}
 	return nil
 }
 
 // Refresh UE information for all UEs
 func (am *AssetMgr) refreshAllUe() (err error) {
+	if profiling {
+		profilingTimers["refreshAllUe"] = time.Now()
+	}
 
 	// Initialize UE information map
 	ueMap := make(map[string]*Ue)
@@ -1595,12 +1621,23 @@ func (am *AssetMgr) refreshAllUe() (err error) {
 	if err != nil {
 		return err
 	}
+
+	if profiling {
+		now := time.Now()
+		log.Debug("- refreshAllUe: ", now.Sub(profilingTimers["refreshAllUe"]))
+	}
 	return nil
 }
 
 // Parse UE to POA information results
 func (am *AssetMgr) parseUePoaInfo(name string, ueMap map[string]*Ue, poaMap map[string]bool) (err error) {
+	if profiling {
+		profilingTimers["parseUePoaInfo"] = time.Now()
+	}
 
+	if profiling {
+		profilingTimers["parseUePoaInfo-query"] = time.Now()
+	}
 	// Get full matrix of UE to POA information in order to perform
 	// POA selection & UE measurement calculations
 	var rows *sql.Rows
@@ -1623,6 +1660,15 @@ func (am *AssetMgr) parseUePoaInfo(name string, ueMap map[string]*Ue, poaMap map
 		return err
 	}
 	defer rows.Close()
+
+	if profiling {
+		now := time.Now()
+		log.Debug("-- parseUePoaInfo-query: ", now.Sub(profilingTimers["parseUePoaInfo-query"]))
+	}
+
+	if profiling {
+		profilingTimers["parseUePoaInfo-scan"] = time.Now()
+	}
 
 	for rows.Next() {
 		ueName := ""
@@ -1672,11 +1718,24 @@ func (am *AssetMgr) parseUePoaInfo(name string, ueMap map[string]*Ue, poaMap map
 		log.Error(err)
 	}
 
+	if profiling {
+		now := time.Now()
+		log.Debug("-- parseUePoaInfo-scan: ", now.Sub(profilingTimers["parseUePoaInfo-scan"]))
+	}
+
+	if profiling {
+		now := time.Now()
+		log.Debug("-- parseUePoaInfo: ", now.Sub(profilingTimers["parseUePoaInfo"]))
+	}
 	return nil
 }
 
 // reset UE Poa Info
 func (am *AssetMgr) resetUePoaInfo(name string, ueMap map[string]*Ue) (err error) {
+	if profiling {
+		profilingTimers["resetUePoaInfo"] = time.Now()
+	}
+
 	if name == "" {
 		rows, err := am.db.Query(`SELECT name FROM ` + UeTable)
 		if err != nil {
@@ -1717,13 +1776,18 @@ func (am *AssetMgr) resetUePoaInfo(name string, ueMap map[string]*Ue) (err error
 		ueMap[name] = ue
 	}
 
+	if profiling {
+		now := time.Now()
+		log.Debug("-- resetUePoaInfo: ", now.Sub(profilingTimers["resetUePoaInfo"]))
+	}
 	return nil
 }
 
 // Update all UE Poa Info
 func (am *AssetMgr) updateUeInfo(ueMap map[string]*Ue) (err error) {
-
-	// start := time.Now()
+	if profiling {
+		profilingTimers["updateUeInfo"] = time.Now()
+	}
 
 	// Begin Update Transaction
 	tx, err := am.db.Begin()
@@ -1791,9 +1855,10 @@ func (am *AssetMgr) updateUeInfo(ueMap map[string]*Ue) (err error) {
 		}
 	}
 
-	// finish := time.Now()
-	// log.Error("UPDATE DURATION: ", finish.Sub(start))
-
+	if profiling {
+		now := time.Now()
+		log.Debug("-- updateUeInfo: ", now.Sub(profilingTimers["updateUeInfo"]))
+	}
 	return nil
 }
 

--- a/go-packages/meep-gis-asset-mgr/asset-mgr.go
+++ b/go-packages/meep-gis-asset-mgr/asset-mgr.go
@@ -40,7 +40,7 @@ const (
 )
 
 // Enable profiling
-const profiling = true
+const profiling = false
 
 var profilingTimers map[string]time.Time
 

--- a/go-packages/meep-metrics/sandbox.go
+++ b/go-packages/meep-metrics/sandbox.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+const SboxMetName = "sbox"
+const SboxMetType = "type"
+const SboxMetSboxName = "sboxname"
+const SboxMetCreateTime = "createtime"
+const SboxMetTime = "time"
+
+// Sandbox metric types
+const (
+	SboxMetTypeCreate = "create"
+)
+
+type SandboxMetric struct {
+	Time       interface{}
+	Name       string
+	CreateTime float64
+}
+
+// SetSandboxMetric
+func (ms *MetricStore) SetSandboxMetric(typ string, sm SandboxMetric) error {
+	metricList := make([]Metric, 1)
+	metric := &metricList[0]
+	metric.Name = SboxMetName
+	metric.Tags = map[string]string{SboxMetType: typ}
+	metric.Fields = map[string]interface{}{
+		SboxMetSboxName:   sm.Name,
+		SboxMetCreateTime: sm.CreateTime,
+	}
+	return ms.SetInfluxMetric(metricList)
+}
+
+// GetSandboxMetric
+func (ms *MetricStore) GetSandboxMetric(typ string, duration string, count int) (metrics []SandboxMetric, err error) {
+	// Make sure we have set a store
+	if ms.name == "" {
+		err = errors.New("Store name not specified")
+		return
+	}
+
+	// Get Sandbox metrics
+	tags := map[string]string{}
+	if typ != "" {
+		tags[SboxMetType] = typ
+	}
+	fields := []string{SboxMetSboxName, SboxMetCreateTime}
+	var valuesArray []map[string]interface{}
+	valuesArray, err = ms.GetInfluxMetric(SboxMetName, tags, fields, duration, count)
+	if err != nil {
+		log.Error("Failed to retrieve metrics with error: ", err.Error())
+		return
+	}
+	// Format sandbox metrics
+	metrics = make([]SandboxMetric, len(valuesArray))
+	for index, values := range valuesArray {
+		metrics[index].Time = values[SboxMetTime]
+		if val, ok := values[SboxMetSboxName].(string); ok {
+			metrics[index].Name = val
+		}
+		metrics[index].CreateTime = JsonNumToFloat64(values[SboxMetCreateTime].(json.Number))
+	}
+	return
+}

--- a/go-packages/meep-metrics/sandbox_test.go
+++ b/go-packages/meep-metrics/sandbox_test.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+const sandboxStoreName string = "sandbox-store"
+const sandboxStoreNamespace string = "common"
+const sandboxStoreInfluxAddr string = "http://localhost:30986"
+const sandboxStoreRedisAddr string = MetricsDbDisabled
+
+func TestSandboxMetricsGetSet(t *testing.T) {
+	fmt.Println("--- ", t.Name())
+	log.MeepTextLogInit(t.Name())
+
+	fmt.Println("Create valid Metric Store")
+	ms, err := NewMetricStore(sandboxStoreName, sandboxStoreNamespace, sandboxStoreInfluxAddr, sandboxStoreRedisAddr)
+	if err != nil {
+		t.Fatalf("Unable to create Metric Store")
+	}
+
+	fmt.Println("Flush store metrics")
+	ms.Flush()
+
+	fmt.Println("Set sandbox metric")
+	err = ms.SetSandboxMetric(SboxMetTypeCreate, SandboxMetric{nil, "sbox1", 12.34})
+	if err != nil {
+		t.Fatalf("Unable to set sandbox metric")
+	}
+	err = ms.SetSandboxMetric(SboxMetTypeCreate, SandboxMetric{nil, "sbox2", 56.789})
+	if err != nil {
+		t.Fatalf("Unable to set sandbox metric")
+	}
+
+	fmt.Println("Get sandbox metrics")
+	sml, err := ms.GetSandboxMetric(SboxMetTypeCreate, "1ms", 0)
+	if err != nil || len(sml) != 0 {
+		t.Fatalf("No metrics should be found in the last 1 ms")
+	}
+	sml, err = ms.GetSandboxMetric(SboxMetTypeCreate, "", 1)
+	fmt.Println(len(sml))
+	if err != nil || len(sml) != 1 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSandboxMetric(sml[0], "sbox2", 56.789) {
+		t.Fatalf("Invalid sandbox metric")
+	}
+	sml, err = ms.GetSandboxMetric(SboxMetTypeCreate, "", 0)
+	if err != nil || len(sml) != 2 {
+		t.Fatalf("Failed to get metric")
+	}
+	if !validateSandboxMetric(sml[0], "sbox2", 56.789) {
+		t.Fatalf("Invalid sandbox metric")
+	}
+	if !validateSandboxMetric(sml[1], "sbox1", 12.34) {
+		t.Fatalf("Invalid sandbox metric")
+	}
+
+	// t.Fatalf("DONE")
+}
+
+func validateSandboxMetric(sm SandboxMetric, name string, createtime float64) bool {
+	if sm.Name != name {
+		fmt.Println("sm.Name[" + sm.Name + "] != name [" + name + "]")
+		return false
+	}
+	if sm.CreateTime != createtime {
+		fmt.Println("sm.CreateTime[" + strconv.FormatFloat(sm.CreateTime, 'f', -1, 64) + "] != createtime [" + strconv.FormatFloat(createtime, 'f', -1, 64) + "]")
+		return false
+	}
+	return true
+}

--- a/go-packages/meep-metrics/session.go
+++ b/go-packages/meep-metrics/session.go
@@ -30,6 +30,7 @@ const SesMetSid = "sid"
 const SesMetSbox = "sbox"
 const SesMetErrType = "errtype"
 const SesMetDesc = "description"
+const SesMetTime = "time"
 
 // Session metric types
 const (
@@ -95,7 +96,7 @@ func (ms *MetricStore) GetSessionMetric(typ string, duration string, count int) 
 	// Format event metrics
 	metrics = make([]SessionMetric, len(valuesArray))
 	for index, values := range valuesArray {
-		metrics[index].Time = values[NetMetTime]
+		metrics[index].Time = values[SesMetTime]
 		if val, ok := values[SesMetProvider].(string); ok {
 			metrics[index].Provider = val
 		}


### PR DESCRIPTION
**CHANGES:**
- Grafana:
  - Configuration update to allow 1s refresh intervals
  - Platform Dashboard update to display Sandbox metrics
- GIS Engine:
  - Fix to prevent automation loop concurrency issue
  - Updated profiling code (disabled by default)
- Monitoring Engine:
  - Sandbox creation time monitoring
  - Metrics send to influx DB & Prometheus DB with creation time
- meep-metrics:
  - Added sandbox metrics to package
  - Added UT

**TESTING:**
- Cypress & UT pass
- Manual verification of dashboard updates
