### PR TITLE
GIS Engine deadlock fix

### DIFF
--- a/go-apps/meep-gis-engine/server/gis-automation.go
+++ b/go-apps/meep-gis-engine/server/gis-automation.go
@@ -60,8 +60,6 @@ func resetAutomation() {
 }
 
 func setAutomation(automationType string, state bool) (err error) {
-	ge.mutex.Lock()
-	defer ge.mutex.Unlock()
 
 	// Validate automation type
 	if _, found := ge.automation[automationType]; !found {
@@ -491,6 +489,9 @@ func geSetAutomationStateByName(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set automation state
+	ge.mutex.Lock()
+	defer ge.mutex.Unlock()
+
 	err := setAutomation(automationType, automationState)
 	if err != nil {
 		log.Error(err.Error())


### PR DESCRIPTION
**CHANGES:**
- GIS Engine: moved mutex to prevent deadlock

**TESTING:**
- Verified that deadlock is no longer occurring in system tests