### PR TITLE
notification for NrMeasRepUe subscription 4G and 5G neighbor cell information is mutually exclusive

### DIFF
--- a/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
+++ b/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
@@ -26,11 +26,11 @@ package server
 type MeasRepUeNotificationEutranNeighbourCellMeasInfo struct {
 	Ecgi *Ecgi `json:"ecgi,omitempty"`
 	// Reference Signal Received Power as defined in ETSI TS 136 214 [i.5].
-	Rsrp int32 `json:"rsrp,omitempty"`
+	Rsrp int32 `json:"rsrp"`
 	// Extended Reference Signal Received Power, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrpEx int32 `json:"rsrpEx,omitempty"`
 	// Reference Signal Received Quality as defined in ETSI TS 136 214 [i.5].
-	Rsrq int32 `json:"rsrq,omitempty"`
+	Rsrq int32 `json:"rsrq"`
 	// Extended Reference Signal Received Quality, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrqEx int32 `json:"rsrqEx,omitempty"`
 	// Reference Signal \"Signal to Interference plus Noise Ratio\", with value mapping defined in ETSI TS 136 133 [i.16].

--- a/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
+++ b/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
@@ -26,11 +26,11 @@ package server
 type MeasRepUeNotificationEutranNeighbourCellMeasInfo struct {
 	Ecgi *Ecgi `json:"ecgi,omitempty"`
 	// Reference Signal Received Power as defined in ETSI TS 136 214 [i.5].
-	Rsrp int32 `json:"rsrp"`
+	Rsrp int32 `json:"rsrp,omitempty"`
 	// Extended Reference Signal Received Power, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrpEx int32 `json:"rsrpEx,omitempty"`
 	// Reference Signal Received Quality as defined in ETSI TS 136 214 [i.5].
-	Rsrq int32 `json:"rsrq"`
+	Rsrq int32 `json:"rsrq,omitempty"`
 	// Extended Reference Signal Received Quality, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrqEx int32 `json:"rsrqEx,omitempty"`
 	// Reference Signal \"Signal to Interference plus Noise Ratio\", with value mapping defined in ETSI TS 136 133 [i.16].

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -1647,8 +1647,6 @@ func checkNrMrNotificationRegisteredSubscriptions(key string, jsonInfo string, e
 					}
 				}
 				if report5GNeighborOnly {
-					log.Info("SIMON4 ", report5GNeighborOnly)
-
 					notif.EutraNeighCellMeasInfo = nil
 				}
 

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -1476,6 +1476,9 @@ func checkMrNotificationRegisteredSubscriptions(key string, jsonInfo string, ext
 						}
 
 						poaInfo := convertJsonToPoaInfo(jsonInfo)
+						//4G and 5G neighbours information are mutually exclusive
+						//If at least one 5G neighbor exist, only report 5G
+						report5GNeighborOnly := false
 
 						switch poaInfo.Type {
 						case poaType4G:
@@ -1494,9 +1497,13 @@ func checkMrNotificationRegisteredSubscriptions(key string, jsonInfo string, ext
 							measRepUeNotificationNrNCellInfo.NrNCellGId = poaInfo.Nrcgi.NrcellId
 							neighborCell.NrNCellInfo = append(neighborCell.NrNCellInfo, measRepUeNotificationNrNCellInfo)
 							notif.NewRadioMeasNeiInfo = append(notif.NewRadioMeasNeiInfo, neighborCell)
+							report5GNeighborOnly = true
 						default:
 						}
 
+						if report5GNeighborOnly {
+							notif.EutranNeighbourCellMeasInfo = nil
+						}
 					}
 				}
 
@@ -2021,6 +2028,7 @@ func subscriptionsPost(w http.ResponseWriter, r *http.Request) {
 				supportedTriggerAlreadyPresent = true
 			}
 		}
+
 		if !supportedTriggerAlreadyPresent {
 			subscription.FilterCriteriaAssocTri.Trigger = append(subscription.FilterCriteriaAssocTri.Trigger, TRIGGER_PERIODICAL_REPORT_STRONGEST_CELLS)
 		}


### PR DESCRIPTION
changing the notification to report 5G but if no 5G neighbors are present, only 4G information shall be returned (mutually exclusive)

testing:
notifications were validated