### PR TITLE
RSRP, RSRQ, RSSI valid range update

### DIFF
--- a/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
+++ b/go-apps/meep-rnis/server/model_meas_rep_ue_notification_eutran_neighbour_cell_meas_info.go
@@ -26,11 +26,11 @@ package server
 type MeasRepUeNotificationEutranNeighbourCellMeasInfo struct {
 	Ecgi *Ecgi `json:"ecgi,omitempty"`
 	// Reference Signal Received Power as defined in ETSI TS 136 214 [i.5].
-	Rsrp int32 `json:"rsrp,omitempty"`
+	Rsrp int32 `json:"rsrp"`
 	// Extended Reference Signal Received Power, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrpEx int32 `json:"rsrpEx,omitempty"`
 	// Reference Signal Received Quality as defined in ETSI TS 136 214 [i.5].
-	Rsrq int32 `json:"rsrq,omitempty"`
+	Rsrq int32 `json:"rsrq"`
 	// Extended Reference Signal Received Quality, with value mapping defined in ETSI TS 136 133 [i.16].
 	RsrqEx int32 `json:"rsrqEx,omitempty"`
 	// Reference Signal \"Signal to Interference plus Noise Ratio\", with value mapping defined in ETSI TS 136 133 [i.16].

--- a/go-apps/meep-rnis/server/model_nr_meas_rep_ue_notification_eutra_neigh_cell_meas_info.go
+++ b/go-apps/meep-rnis/server/model_nr_meas_rep_ue_notification_eutra_neigh_cell_meas_info.go
@@ -26,9 +26,9 @@ package server
 type NrMeasRepUeNotificationEutraNeighCellMeasInfo struct {
 	Ecgi *Ecgi `json:"ecgi,omitempty"`
 	// Reference Signal Received Power as defined in ETSI TS 138 331 [i.13].
-	Rsrp int32 `json:"rsrp,omitempty"`
+	Rsrp int32 `json:"rsrp"`
 	// Reference Signal Received Quality as defined in ETSI TS 138 331 [i.13].
-	Rsrq int32 `json:"rsrq,omitempty"`
+	Rsrq int32 `json:"rsrq"`
 	// Reference Signal plus Interference Noise Ratio as defined in ETSI TS 138 331 [i.13].
 	Sinr int32 `json:"sinr,omitempty"`
 }

--- a/go-packages/meep-gis-asset-mgr/asset-mgr.go
+++ b/go-packages/meep-gis-asset-mgr/asset-mgr.go
@@ -1954,15 +1954,21 @@ func calculatePower(subtype string, radius float32, distance float32) (rssi floa
 }
 
 // 4G Cellular signal strength calculator
+// OFFICIAL COMPLETE RANGE
 // RSRP power range: -156 dBm to -44 dBm
 // Equivalent RSRP range: -17 to 97
 // RSRQ power range: -34 dBm to 2.5 dBm
 // Equivalent RSRQ range: -30 to 46
+// IMPLEMENTED RANGE TO ONLY TAKE INTO ACCOUNT REAL WORLD SIGNAL STRENGHT
+// RSRP power range: -100 dBm to -70 dBm
+// Equivalent RSRP range: 39 to 69
+// RSRQ power range: -20 dBm to -5 dBm
+// Equivalent RSRQ range: -2 to 28
 // Algorithm: Linear proportion to distance over radius, if in range
-const minCell4gRsrp = float32(-17)
-const maxCell4gRsrp = float32(97)
-const minCell4gRsrq = float32(-30)
-const maxCell4gRsrq = float32(46)
+const minCell4gRsrp = float32(39)
+const maxCell4gRsrp = float32(69)
+const minCell4gRsrq = float32(-2)
+const maxCell4gRsrq = float32(28)
 
 func calculateCell4gPower(radius float32, distance float32) (rsrp float32, rsrq float32) {
 	rsrp = minCell4gRsrp
@@ -1979,11 +1985,17 @@ func calculateCell4gPower(radius float32, distance float32) (rsrp float32, rsrq 
 // Equivalent RSRP range: 0 to 127
 // RSRQ power range: -43 dBm to 20 dBm
 // Equivalent RSRQ range: 0 to 127
+// IMPLEMENTED RANGE TO ONLY TAKE INTO ACCOUNT REAL WORLD SIGNAL STRENGHT
+// RSRP power range: -115 dBm to -65 dBm
+// Equivalent RSRP range: 39 to 92
+// RSRQ power range: -20 dBm to -5 dBm (valid range actuallu -43 to 20 dB
+// Equivalent RSRQ range: 47 to 77
 // Algorithm: Linear proportion to distance over radius, if in range
-const minCell5gRsrp = float32(0)
-const maxCell5gRsrp = float32(127)
-const minCell5gRsrq = float32(0)
-const maxCell5gRsrq = float32(127)
+// Algorithm: Linear proportion to distance over radius, if in range
+const minCell5gRsrp = float32(39)
+const maxCell5gRsrp = float32(92)
+const minCell5gRsrq = float32(47)
+const maxCell5gRsrq = float32(77)
 
 func calculateCell5gPower(radius float32, distance float32) (rsrp float32, rsrq float32) {
 	rsrp = minCell5gRsrp
@@ -1998,9 +2010,12 @@ func calculateCell5gPower(radius float32, distance float32) (rsrp float32, rsrq 
 // WiFi signal strength calculator
 // Signal power range: -113 dBm to -10 dBm
 // Equivalent RSSI range: 0 to 100
+// IMPLEMENTED RANGE TO ONLY TAKE INTO ACCOUNT REAL WORLD SIGNAL STRENGHT
+// Signal power range: -80 dBm to -30 dBm
+// Equivalent RSSI range: 32 to 77
 // Algorithm: Linear proportion to distance over radius, if in range
-const minWifiRssi = float32(0)
-const maxWifiRssi = float32(100)
+const minWifiRssi = float32(32)
+const maxWifiRssi = float32(77)
 
 func calculateWifiPower(radius float32, distance float32) (rssi float32) {
 	rssi = minWifiRssi

--- a/go-packages/meep-gis-asset-mgr/asset-mgr.go
+++ b/go-packages/meep-gis-asset-mgr/asset-mgr.go
@@ -1987,12 +1987,11 @@ func calculateCell4gPower(radius float32, distance float32) (rsrp float32, rsrq 
 // Equivalent RSRQ range: 0 to 127
 // IMPLEMENTED RANGE TO ONLY TAKE INTO ACCOUNT REAL WORLD SIGNAL STRENGHT
 // RSRP power range: -115 dBm to -65 dBm
-// Equivalent RSRP range: 39 to 92
-// RSRQ power range: -20 dBm to -5 dBm (valid range actuallu -43 to 20 dB
+// Equivalent RSRP range: 42 to 92
+// RSRQ power range: -20 dBm to -5 dBm
 // Equivalent RSRQ range: 47 to 77
 // Algorithm: Linear proportion to distance over radius, if in range
-// Algorithm: Linear proportion to distance over radius, if in range
-const minCell5gRsrp = float32(39)
+const minCell5gRsrp = float32(42)
 const maxCell5gRsrp = float32(92)
 const minCell5gRsrq = float32(47)
 const maxCell5gRsrq = float32(77)


### PR DESCRIPTION
Signal strength based on distance to the POA were updated to match realistic signal powers for connected Ues.

4G:
RSRP : [-100, -70] dBm -> [39, 69]
RSRQ : [-20, -5] dBm -> [-2, 28]

5G
RSRP : [-115, -65] dBm -> [42, 92]
RSRQ : [-20, -5] dBm -> [47, 77]

Wifi
RSSI : [-80, -30] dBm -> [32, 77] (based on cisco scale)

- Updating rsrq and rsrp in 4G to make them mandatory parameters rather than optional
This is to make sure they show up if value is 0 and it is a valid one. In the case of rsrq this may be a valid value (but not for rsrp). Forcing both to show up to track that if both are 0, it means there is an error and it should be investigated... 

Testing
verified values are present within the new specified range