### PR TITLE
Power signal updates on active scenario updates

### DIFF
--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -354,6 +354,18 @@ func updateUeData(obj sbi.UeDataSbi) {
 	ueData.ThroughputDL = obj.ThroughputDL
 	ueData.PacketLoss = obj.PacketLoss
 
+	var inRangePoas []InRangePoa
+	for index := range obj.InRangePoas {
+		var inRangePoa InRangePoa
+		inRangePoa.Name = obj.InRangePoas[index]
+		inRangePoa.Rsrp = obj.InRangeRsrps[index]
+		inRangePoa.Rsrq = obj.InRangeRsrqs[index]
+		inRangePoas = append(inRangePoas, inRangePoa)
+	}
+
+	ueData.InRangePoas = inRangePoas
+	ueData.ParentPoaName = obj.ParentPoaName
+
 	oldPlmn := new(Plmn)
 	oldPlmnMnc := ""
 	oldPlmnMcc := ""
@@ -362,6 +374,7 @@ func updateUeData(obj sbi.UeDataSbi) {
 	oldNrPlmnMnc := ""
 	oldNrPlmnMcc := ""
 	oldNrCellId := ""
+	var oldInRangePoas []InRangePoa
 
 	//get from DB
 	jsonUeData, _ := rc.JSONGetEntry(baseKey+"UE:"+obj.Name, ".")
@@ -381,9 +394,10 @@ func updateUeData(obj sbi.UeDataSbi) {
 				oldNrPlmnMcc = ueDataObj.Nrcgi.Plmn.Mcc
 				oldNrCellId = ueDataObj.Nrcgi.NrcellId
 			}
-
+			oldInRangePoas = ueDataObj.InRangePoas
 		}
 	}
+
 	//updateDB if changes occur (4G section)
 	if newEcgi.Plmn.Mnc != oldPlmnMnc || newEcgi.Plmn.Mcc != oldPlmnMcc || newEcgi.CellId != oldCellId {
 
@@ -423,6 +437,23 @@ func updateUeData(obj sbi.UeDataSbi) {
 		//5G section
 		if newNrcgi.Plmn.Mnc != oldNrPlmnMnc || newNrcgi.Plmn.Mcc != oldNrPlmnMcc || newNrcgi.NrcellId != oldNrCellId {
 			//update because nrcgi changed
+			_ = rc.JSONSetEntry(baseKey+"UE:"+obj.Name, ".", convertUeDataToJson(&ueData))
+		}
+		//update if poa in range and signal powers changed
+		//as soon as there is one difference... need an update
+		updateMeas := false
+		if len(oldInRangePoas) != len(inRangePoas) {
+			updateMeas = true
+		} else {
+			for index := range oldInRangePoas {
+				if oldInRangePoas[index].Name != inRangePoas[index].Name || oldInRangePoas[index].Rsrp != inRangePoas[index].Rsrp || oldInRangePoas[index].Rsrq != inRangePoas[index].Rsrq {
+					updateMeas = true
+					break
+				}
+			}
+		}
+		if updateMeas {
+			//update because power signals changed
 			_ = rc.JSONSetEntry(baseKey+"UE:"+obj.Name, ".", convertUeDataToJson(&ueData))
 		}
 	}

--- a/go-packages/meep-gis-asset-mgr/asset-mgr.go
+++ b/go-packages/meep-gis-asset-mgr/asset-mgr.go
@@ -1839,6 +1839,9 @@ func (am *AssetMgr) updateUeInfo(ueMap map[string]*Ue) (err error) {
 		for poaName, meas := range ue.Measurements {
 			// Calculate power measurements
 			rssi, rsrp, rsrq := calculatePower(meas.SubType, meas.Radius, meas.Distance)
+			if rsrp == 0 && rsrq == 0 {
+				log.Error("ERROR: Zero Rsrp and RsRq should not happen: ", meas.SubType, "---", meas.Radius, "---", meas.Distance, "---", poaName, "---", ueName)
+			}
 
 			// Add new entry or update existing one
 			id := ueName + "-" + poaName


### PR DESCRIPTION
Power signals in GIScache updated every time a UE changes position.

GIS cache power signal were only red on a 1s refresh ticker in RNIS. The GIS cache info needs to be read whenever an active scenario update is received too, otherwise, measurements information (power signal) is only read after the ticker... which might be too late after a notification with the "signal power" is sent. \

This fix ensure they are read in both instances

test:
UT passed