### PR TITLE
Codecoverage enabled for core and sandbox pods

### DIFF
--- a/.meepctl-repocfg.yaml
+++ b/.meepctl-repocfg.yaml
@@ -393,7 +393,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -417,7 +417,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -441,7 +441,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -462,7 +462,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -486,7 +486,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -510,7 +510,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -531,7 +531,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
         # location of API specification
@@ -555,7 +555,7 @@ repo:
         # enable meepctl deploy/delete
         deploy: true
         # supports code coverage measurement when built in codecov mode
-        codecov: false
+        codecov: true
         # supports linting
         lint: true
       meep-tc-sidecar:

--- a/charts/meep-gis-engine/templates/codecov-pv.yaml
+++ b/charts/meep-gis-engine/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-gis-engine"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-gis-engine/values-template.yaml
+++ b/charts/meep-gis-engine/values-template.yaml
@@ -50,6 +50,7 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-gis-engine"
 
 meepOrigin: core
 

--- a/charts/meep-loc-serv/templates/codecov-pv.yaml
+++ b/charts/meep-loc-serv/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-loc-serv"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -51,5 +51,6 @@ prometheus:
 
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-loc-serv"
 
 meepOrigin: core

--- a/charts/meep-metrics-engine/templates/codecov-pv.yaml
+++ b/charts/meep-metrics-engine/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-metrics-engine"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-metrics-engine/values-template.yaml
+++ b/charts/meep-metrics-engine/values-template.yaml
@@ -51,5 +51,6 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-metrics-engine"
 
 meepOrigin: core

--- a/charts/meep-mg-manager/templates/codecov-pv.yaml
+++ b/charts/meep-mg-manager/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-mg-manager"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-mg-manager/values-template.yaml
+++ b/charts/meep-mg-manager/values-template.yaml
@@ -58,5 +58,6 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-mg-manager"
 
 meepOrigin: core

--- a/charts/meep-mon-engine/templates/codecov-pv.yaml
+++ b/charts/meep-mon-engine/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-mon-engine"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-mon-engine/values.yaml
+++ b/charts/meep-mon-engine/values.yaml
@@ -54,5 +54,6 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-mon-engine"
 
 meepOrigin: core

--- a/charts/meep-rnis/templates/codecov-pv.yaml
+++ b/charts/meep-rnis/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-rnis"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-rnis/values-template.yaml
+++ b/charts/meep-rnis/values-template.yaml
@@ -53,5 +53,6 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-rnis"
 
 meepOrigin: core

--- a/charts/meep-sandbox-ctrl/templates/codecov-pv.yaml
+++ b/charts/meep-sandbox-ctrl/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-sandbox-ctrl"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-sandbox-ctrl/values-template.yaml
+++ b/charts/meep-sandbox-ctrl/values-template.yaml
@@ -72,5 +72,6 @@ user:
     servepath: "/user-swagger-sandbox"
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-sandbox-ctrl"
 
 meepOrigin: core

--- a/charts/meep-tc-engine/templates/codecov-pv.yaml
+++ b/charts/meep-tc-engine/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-tc-engine"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-tc-engine/values-template.yaml
+++ b/charts/meep-tc-engine/values-template.yaml
@@ -32,5 +32,6 @@ service:
 
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-tc-engine"
   
 meepOrigin: core

--- a/charts/meep-virt-engine/templates/codecov-pv.yaml
+++ b/charts/meep-virt-engine/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-virt-engine"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-virt-engine/values.yaml
+++ b/charts/meep-virt-engine/values.yaml
@@ -61,5 +61,6 @@ user:
 
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-virt-engine"
 
 meepOrigin: core

--- a/charts/meep-wais/templates/codecov-pv.yaml
+++ b/charts/meep-wais/templates/codecov-pv.yaml
@@ -11,7 +11,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
-    path: "/home/englab/.meep/codecov/meep-wais"
+    path: {{ .Values.codecov.location }}
 
 ---
 kind: StorageClass

--- a/charts/meep-wais/values-template.yaml
+++ b/charts/meep-wais/values-template.yaml
@@ -51,5 +51,6 @@ prometheus:
     
 codecov:
   enabled: false
+  location: "<WORKDIR>/codecov/meep-wais"
 
 meepOrigin: core

--- a/go-apps/meep-rnis/main_test.go
+++ b/go-apps/meep-rnis/main_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+// Build:
+//  $ go test -covermode=count -coverpkg=./... -c -o <name-of-your-app>
+// Run:
+//  $ ./<name-of-your-app> -test.coverprofile=cover.out __DEVEL--code-cov  <your-app-args>
+
+// TestMain is a hack that allows us to figure out what the coverage is during
+// integration tests. I would not recommend that you use a binary built using
+// this hack outside of a test suite.
+func TestMain(t *testing.T) {
+	var (
+		args []string
+		run  bool
+	)
+
+	log.Info(os.Args)
+	for _, arg := range os.Args {
+		switch {
+		case arg == "__DEVEL--code-cov":
+			run = true
+		case strings.HasPrefix(arg, "-test"):
+		case strings.HasPrefix(arg, "__DEVEL"):
+		default:
+			args = append(args, arg)
+		}
+	}
+	os.Args = args
+	log.Info(os.Args)
+
+	if run {
+		main()
+	}
+}

--- a/go-apps/meep-virt-engine/helm/install.go
+++ b/go-apps/meep-virt-engine/helm/install.go
@@ -18,6 +18,7 @@ package helm
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -61,11 +62,14 @@ func install(chart Chart) error {
 	log.Debug("Installing chart: " + chart.ReleaseName)
 	var cmd *exec.Cmd
 	if strings.Trim(chart.ValuesFile, " ") == "" {
+		codecovLocation := strings.TrimSpace(os.Getenv("MEEP_CODECOV_LOCATION")) + chart.ReleaseName
 		cmd = exec.Command("helm", "install", chart.ReleaseName,
 			"--namespace", chart.Namespace, "--create-namespace",
 			"--set", "nameOverride="+chart.Name,
 			"--set", "fullnameOverride="+chart.Name,
-			chart.Location, "--replace", "--disable-openapi-validation")
+			chart.Location, "--replace", "--disable-openapi-validation",
+			"--set", "codecov.enabled="+strings.TrimSpace(os.Getenv("MEEP_CODECOV")),
+			"--set", "codecov.location="+codecovLocation)
 	} else {
 		cmd = exec.Command("helm", "install", chart.ReleaseName,
 			"--namespace", chart.Namespace, "--create-namespace",

--- a/go-apps/meep-wais/main_test.go
+++ b/go-apps/meep-wais/main_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+// Build:
+//  $ go test -covermode=count -coverpkg=./... -c -o <name-of-your-app>
+// Run:
+//  $ ./<name-of-your-app> -test.coverprofile=cover.out __DEVEL--code-cov  <your-app-args>
+
+// TestMain is a hack that allows us to figure out what the coverage is during
+// integration tests. I would not recommend that you use a binary built using
+// this hack outside of a test suite.
+func TestMain(t *testing.T) {
+	var (
+		args []string
+		run  bool
+	)
+
+	log.Info(os.Args)
+	for _, arg := range os.Args {
+		switch {
+		case arg == "__DEVEL--code-cov":
+			run = true
+		case strings.HasPrefix(arg, "-test"):
+		case strings.HasPrefix(arg, "__DEVEL"):
+		default:
+			args = append(args, arg)
+		}
+	}
+	os.Args = args
+	log.Info(os.Args)
+
+	if run {
+		main()
+	}
+}

--- a/go-apps/meepctl/cmd/deploy.go
+++ b/go-apps/meepctl/cmd/deploy.go
@@ -192,6 +192,8 @@ func deployCore(cobraCmd *cobra.Command) {
 		coreFlags := utils.HelmFlags(flags, "--set", "image.repository="+deployData.registry+"/"+app)
 		coreFlags = utils.HelmFlags(coreFlags, "--set", "image.tag="+deployData.tag)
 		if deployData.codecov && codecov {
+			coreFlags = utils.HelmFlags(coreFlags, "--set", "image.env.MEEP_CODECOV='true'")
+			coreFlags = utils.HelmFlags(coreFlags, "--set", "image.env.MEEP_CODECOV_LOCATION="+deployData.workdir+"/codecov/")
 			coreFlags = utils.HelmFlags(coreFlags, "--set", "codecov.enabled=true")
 			coreFlags = utils.HelmFlags(coreFlags, "--set", "codecov.location="+deployData.workdir+"/codecov/"+app)
 		}


### PR DESCRIPTION
Chnages:
- Fixed typo in documentation for build with codecov flag
- Added test file in `meep-rnis` and `meep-wais` microservices
- Removed hardcoded paths from `meep-mon-engine`,`meep-virt-engine`,`meep-gis-engine`,`meep-loc-serv`,`meep-metrics-engine`,`meep-mg-manager`,`meep-sandbox-ctrl`,`meep-tc-engine`,`meep-wais`, and `meep-rnis`
- Change helm install file in `meep-virt-engine` to add codecov flag based on build for `meep-virt-engine`

Tests:
- Manually checked if codecov files are generated or not