### PR TITLE
AppSupport application termination subscription support

### DIFF
--- a/go-apps/meep-app-enablement/server/app-info/app-info.go
+++ b/go-apps/meep-app-enablement/server/app-info/app-info.go
@@ -113,7 +113,7 @@ func Init() (err error) {
 	// Set base path
 	basePath = "/" + sandboxName + appInfoBasePath
 	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + selfName + ":" + appEnablementKey
+	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":meep:" + selfName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)

--- a/go-apps/meep-app-enablement/server/app-info/app-info.go
+++ b/go-apps/meep-app-enablement/server/app-info/app-info.go
@@ -113,7 +113,7 @@ func Init() (err error) {
 	// Set base path
 	basePath = "/" + sandboxName + appInfoBasePath
 	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":meep:" + selfName
+	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + selfName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)

--- a/go-apps/meep-app-enablement/server/app-support/api_app_subscriptions.go
+++ b/go-apps/meep-app-enablement/server/app-support/api_app_subscriptions.go
@@ -28,21 +28,17 @@ import (
 )
 
 func ApplicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
+	applicationsSubscriptionDELETE(w, r)
 }
 
 func ApplicationsSubscriptionGET(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
+	applicationsSubscriptionGET(w, r)
 }
 
 func ApplicationsSubscriptionsGET(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
+	applicationsSubscriptionsGET(w, r)
 }
 
 func ApplicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.WriteHeader(http.StatusOK)
+	applicationsSubscriptionsPOST(w, r)
 }

--- a/go-apps/meep-app-enablement/server/app-support/app-support.go
+++ b/go-apps/meep-app-enablement/server/app-support/app-support.go
@@ -38,7 +38,7 @@ import (
 )
 
 const mappsupportBasePath = "/mec_app_support/v1/"
-const mappsupportKey = "as-sub"
+const mappsupportKey = "as"
 const appEnablementKey = "app-enablement"
 const ACTIVE = "ACTIVE"
 const INACTIVE = "INACTIVE"
@@ -145,14 +145,13 @@ func Init(globalMutex *sync.Mutex) (err error) {
 }
 
 // reInit - finds the value already in the DB to repopulate local stored info
+// NOTE: Init is flushing everything so this is a non-operation code, but if a sbi is added that tracks Activation/Termination of scenarios, then this should become handy, leaving it there for future code updates if needed
 func reInit() {
 	//next available subsId will be overrriden if subscriptions already existed
 	nextSubscriptionIdAvailable = 1
 
-	baseKey := appEnablementBaseKey + ":apps:*:" + mappsupportKey
-	keyName := baseKey + ":subscriptions:" + "*"
+	keyName := appEnablementBaseKey + ":apps:*:" + mappsupportKey + ":subscriptions:" + "*"
 	_ = rc.ForEachJSONEntry(keyName, repopulateAppTerminationNotificationSubscriptionMap, nil)
-
 }
 
 // Run - Start APP support
@@ -165,6 +164,7 @@ func Stop() (err error) {
 	return nil
 }
 
+// see NOTE from ReInit()
 func repopulateAppTerminationNotificationSubscriptionMap(key string, jsonInfo string, userData interface{}) error {
 
 	var subscription AppTerminationNotificationSubscription

--- a/go-apps/meep-app-enablement/server/app-support/app-support.go
+++ b/go-apps/meep-app-enablement/server/app-support/app-support.go
@@ -119,8 +119,8 @@ func Init(globalMutex *sync.Mutex) (err error) {
 	// Set base path
 	basePath = "/" + sandboxName + mappsupportBasePath
 	// Get base store key
-	baseKey = dkm.GetKeyRoot(sandboxName) + mappsupportKey
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + selfName + ":" + appEnablementKey
+	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":meep:" + selfName
+	baseKey = appEnablementBaseKey + ":" + mappsupportKey
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)

--- a/go-apps/meep-app-enablement/server/app-support/convert.go
+++ b/go-apps/meep-app-enablement/server/app-support/convert.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019  InterDigital Communications, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"encoding/json"
+
+	log "github.com/InterDigitalInc/AdvantEDGE/go-packages/meep-logger"
+)
+
+func convertAppTerminationNotificationSubscriptionToJson(appTerm *AppTerminationNotificationSubscription) string {
+
+	jsonInfo, err := json.Marshal(*appTerm)
+	if err != nil {
+		log.Error(err.Error())
+		return ""
+	}
+
+	return string(jsonInfo)
+}

--- a/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
@@ -125,7 +125,7 @@ func Init(globalMutex *sync.Mutex) (err error) {
 	// Set base path
 	basePath = "/" + sandboxName + msmgmtBasePath
 	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":meep:" + selfName
+	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + selfName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, MSMGMT_DB)

--- a/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
@@ -125,7 +125,7 @@ func Init(globalMutex *sync.Mutex) (err error) {
 	// Set base path
 	basePath = "/" + sandboxName + msmgmtBasePath
 	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + selfName + ":" + appEnablementKey
+	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":meep:" + selfName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, MSMGMT_DB)


### PR DESCRIPTION
Implementation of :
GET /app-support/{appInstanceId}/subscriptions
POST /app-support/{appInstanceId}/subscriptions

GET /app-support/{appInstanceId}/subscriptions/{subscriptionId}
PUT /app-support/{appInstanceId}/subscriptions/{subscriptionId}
DELETE /app-support/{appInstanceId}/subscriptions/{subscriptionId}

Note : if not subscribed, prevent the termination confirmation message from being processed
Note2: Not rebased on develop, branched off sp_dev_mec011_phase1 for now, will be renased when tip of develop is up-to-date.