### PR TITLE
MEP Support

### DIFF
--- a/charts/meep-app-enablement/templates/clusterrolebinding.yaml
+++ b/charts/meep-app-enablement/templates/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ .Release.Namespace }}:{{ .Values.serviceAccount }}"
+  name: "{{ .Release.Namespace }}:{{ template "meep-app-enablement.fullname" . }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-app-enablement.fullname" . }}
   namespace: {{ .Release.Namespace }}
   

--- a/charts/meep-app-enablement/templates/deployment.yaml
+++ b/charts/meep-app-enablement/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             {{- range $key, $value := .Values.image.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:

--- a/charts/meep-app-enablement/templates/deployment.yaml
+++ b/charts/meep-app-enablement/templates/deployment.yaml
@@ -51,8 +51,9 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
+        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
         - name: init-{{ .Values.deployment.dependency }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
-
+        {{- end}}

--- a/charts/meep-app-enablement/templates/deployment.yaml
+++ b/charts/meep-app-enablement/templates/deployment.yaml
@@ -51,9 +51,15 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
-        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
-        - name: init-{{ .Values.deployment.dependency }}
+        {{- range $value := .Values.deployment.dependencies.system }}
+        - name: init-system-{{ $value }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
+          command: ['sh', '-c', 'until nslookup {{ $value }}.kube-system ; do echo waiting for {{ $value }}; sleep 0.25; done;']
+        {{- end}}
+        {{- range $value := .Values.deployment.dependencies.sandbox }}
+        - name: init-sandbox-{{ $value }}
+          image: busybox:1.28
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'until nslookup {{ $value }} ; do echo waiting for {{ $value }}; sleep 0.25; done;']
         {{- end}}

--- a/charts/meep-app-enablement/templates/ingress.yaml
+++ b/charts/meep-app-enablement/templates/ingress.yaml
@@ -1,11 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "meep-app-enablement.fullname" . -}}
+{{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "meep-app-enablement.fullname" . }}
+  name: {{ $serviceName }}
   labels:
     app: {{ template "meep-app-enablement.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/meep-app-enablement/templates/service.yaml
+++ b/charts/meep-app-enablement/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "meep-app-enablement.fullname" . }}
+  name: {{ .Values.service.name }}
   labels:
     app: {{ template "meep-app-enablement.name" . }}
     chart: {{ template "meep-app-enablement.chart" . }}

--- a/charts/meep-app-enablement/templates/serviceaccount.yaml
+++ b/charts/meep-app-enablement/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-app-enablement.fullname" . }}

--- a/charts/meep-app-enablement/values-template.yaml
+++ b/charts/meep-app-enablement/values-template.yaml
@@ -6,12 +6,12 @@ deployment:
   replicas: 1
   port: 80
   protocol: TCP
-  dependency: kube-dns
-  {{- if .IsMepService }}
-  kubeDnsInitContainerEnabled: false
-  {{- else }}
-  kubeDnsInitContainerEnabled: true
-  {{- end }}
+  dependencies:
+    system:
+      {{- if not .IsMepService }}
+      - kube-dns
+      {{- end }}
+    sandbox:
 
 image:
   repository: meep-docker-registry:30001/meep-app-enablement

--- a/charts/meep-app-enablement/values-template.yaml
+++ b/charts/meep-app-enablement/values-template.yaml
@@ -2,24 +2,37 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-serviceAccount: meep-app-enablement
-
 deployment:
   replicas: 1
   port: 80
   protocol: TCP
   dependency: kube-dns
+  {{- if .IsMepService }}
+  kubeDnsInitContainerEnabled: false
+  {{- else }}
+  kubeDnsInitContainerEnabled: true
+  {{- end }}
 
 image:
   repository: meep-docker-registry:30001/meep-app-enablement
   tag: latest
   pullPolicy: Always
   env:
-    MEEP_SANDBOX_NAME: {{ .SandboxName }}
-    MEEP_HOST_URL: {{ .HostUrl }}
+    MEEP_SANDBOX_NAME: {{.SandboxName}}
+    MEEP_HOST_URL: {{.HostUrl}}
+    {{- if .IsMepService }}
+    MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- range .Env}}
+    {{.}}
+    {{- end}}
 
 service:
+  {{- if .IsMepService }}
+  name: {{.MepName}}-meep-app-enablement
+  {{- else }}
   name: meep-app-enablement
+  {{- end }}
   type: ClusterIP
   port: 80
 
@@ -28,18 +41,31 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /{{ .SandboxName }}/mec_app_support
-        - /{{ .SandboxName }}/mec_service_mgmt
-        - /{{ .SandboxName }}/app_info
+        {{- if .IsMepService }}
+        - /{{.SandboxName}}/{{.MepName}}/mec_app_support
+        - /{{.SandboxName}}/{{.MepName}}/mec_service_mgmt
+        - /{{.SandboxName}}/{{.MepName}}/app_info
+        {{- else }}
+        - /{{.SandboxName}}/mec_app_support
+        - /{{.SandboxName}}/mec_service_mgmt
+        - /{{.SandboxName}}/app_info
+        {{- end }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: {{ .HttpsOnly }}
+    {{- if .IsMepService }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/{{ .SandboxName }}/{{.MepName}}/mec_app_support(/|$)(.*)$ /mec_app_support/$2 break;
+      rewrite ^/{{ .SandboxName }}/{{.MepName}}/mec_service_mgmt(/|$)(.*)$ /mec_service_mgmt/$2 break;
+      rewrite ^/{{ .SandboxName }}/{{.MepName}}/app_info(/|$)(.*)$ /app_info/$2 break;
+    {{- else }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       rewrite ^/{{ .SandboxName }}/mec_app_support(/|$)(.*)$ /mec_app_support/$2 break;
       rewrite ^/{{ .SandboxName }}/mec_service_mgmt(/|$)(.*)$ /mec_service_mgmt/$2 break;
       rewrite ^/{{ .SandboxName }}/app_info(/|$)(.*)$ /app_info/$2 break;
+    {{- end }}
     {{- if .AuthEnabled }}
-    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-app-enablement&sbox={{ .SandboxName }}
+    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-app-enablement&sbox={{.SandboxName}}&mep={{.MepName}}
     {{- end }}
   labels: {}
   tls:

--- a/charts/meep-loc-serv/templates/clusterrolebinding.yaml
+++ b/charts/meep-loc-serv/templates/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ .Release.Namespace }}:{{ .Values.serviceAccount }}"
+  name: "{{ .Release.Namespace }}:{{ template "meep-loc-serv.fullname" . }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-loc-serv.fullname" . }}
   namespace: {{ .Release.Namespace }}
   

--- a/charts/meep-loc-serv/templates/deployment.yaml
+++ b/charts/meep-loc-serv/templates/deployment.yaml
@@ -51,10 +51,15 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
-        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
-        - name: init-{{ .Values.deployment.dependency }}
+        {{- range $value := .Values.deployment.dependencies.system }}
+        - name: init-system-{{ $value }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
+          command: ['sh', '-c', 'until nslookup {{ $value }}.kube-system ; do echo waiting for {{ $value }}; sleep 0.25; done;']
         {{- end}}
-
+        {{- range $value := .Values.deployment.dependencies.sandbox }}
+        - name: init-sandbox-{{ $value }}
+          image: busybox:1.28
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'until nslookup {{ $value }} ; do echo waiting for {{ $value }}; sleep 0.25; done;']
+        {{- end}}

--- a/charts/meep-loc-serv/templates/deployment.yaml
+++ b/charts/meep-loc-serv/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             {{- range $key, $value := .Values.image.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:

--- a/charts/meep-loc-serv/templates/deployment.yaml
+++ b/charts/meep-loc-serv/templates/deployment.yaml
@@ -51,8 +51,10 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
+        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
         - name: init-{{ .Values.deployment.dependency }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
+        {{- end}}
 

--- a/charts/meep-loc-serv/templates/ingress.yaml
+++ b/charts/meep-loc-serv/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "meep-loc-serv.fullname" . -}}
+{{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1

--- a/charts/meep-loc-serv/templates/ingress.yaml
+++ b/charts/meep-loc-serv/templates/ingress.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := .Values.service.name -}}
+{{- $serviceName := include "meep-loc-serv.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/charts/meep-loc-serv/templates/ingress.yaml
+++ b/charts/meep-loc-serv/templates/ingress.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "meep-loc-serv.fullname" . -}}
+{{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "meep-loc-serv.fullname" . }}
+  name: {{ $serviceName }}
   labels:
     app: {{ template "meep-loc-serv.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/meep-loc-serv/templates/service.yaml
+++ b/charts/meep-loc-serv/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.service.name }}
+  name: {{ template "meep-loc-serv.fullname" . }}
   labels:
     app: {{ template "meep-loc-serv.name" . }}
     chart: {{ template "meep-loc-serv.chart" . }}

--- a/charts/meep-loc-serv/templates/service.yaml
+++ b/charts/meep-loc-serv/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "meep-loc-serv.fullname" . }}
+  name: {{ .Values.service.name }}
   labels:
     app: {{ template "meep-loc-serv.name" . }}
     chart: {{ template "meep-loc-serv.chart" . }}

--- a/charts/meep-loc-serv/templates/serviceaccount.yaml
+++ b/charts/meep-loc-serv/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-loc-serv.fullname" . }}

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -2,12 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-{{- if .IsMepService }}
-serviceAccount: meep-loc-serv-{{.MepName}}
-{{- else }}
-serviceAccount: meep-loc-serv
-{{- end }}
-
 deployment:
   replicas: 1
   port: 80

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -28,11 +28,6 @@ image:
     {{- end}}
 
 service:
-  {{- if .IsMepService }}
-  name: meep-loc-serv-{{.MepName}}
-  {{- else }}
-  name: meep-loc-serv
-  {{- end }}
   type: ClusterIP
   port: 80
 

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -28,6 +28,11 @@ image:
     {{- end}}
 
 service:
+  {{- if .IsMepService }}
+  name: {{.MepName}}-meep-loc-serv
+  {{- else }}
+  name: meep-loc-serv
+  {{- end }}
   type: ClusterIP
   port: 80
 

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -6,12 +6,12 @@ deployment:
   replicas: 1
   port: 80
   protocol: TCP
-  dependency: kube-dns
-  {{- if .IsMepService }}
-  kubeDnsInitContainerEnabled: false
-  {{- else }}
-  kubeDnsInitContainerEnabled: true
-  {{- end }}
+  dependencies:
+    system:
+      {{- if not .IsMepService }}
+      - kube-dns
+      {{- end }}
+    sandbox:
 
 image:
   repository: meep-docker-registry:30001/meep-loc-serv
@@ -22,6 +22,11 @@ image:
     MEEP_HOST_URL: {{.HostUrl}}
     {{- if .IsMepService }}
     MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- if eq .AppEnablement "local" }}
+    MEEP_APP_ENABLEMENT: {{.MepName}}-meep-app-enablement
+    {{- else if eq .AppEnablement "global" }}
+    MEEP_APP_ENABLEMENT: meep-app-enablement
     {{- end }}
     {{- range .Env}}
     {{.}}

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -2,24 +2,37 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+{{- if .IsMepService }}
+serviceAccount: meep-loc-serv-{{.MepName}}
+{{- else }}
 serviceAccount: meep-loc-serv
+{{- end }}
 
 deployment:
   replicas: 1
   port: 80
   protocol: TCP
   dependency: kube-dns
+  {{- if .IsMepService }}
+  kubeDnsInitContainerEnabled: false
+  {{- else }}
+  kubeDnsInitContainerEnabled: true
+  {{- end }}
 
 image:
   repository: meep-docker-registry:30001/meep-loc-serv
   tag: latest
   pullPolicy: Always
   env:
-    MEEP_SANDBOX_NAME: {{ .SandboxName }}
-    MEEP_HOST_URL: {{ .HostUrl }}
+    MEEP_SANDBOX_NAME: {{.SandboxName}}
+    MEEP_HOST_URL: {{.HostUrl}}
 
 service:
+  {{- if .IsMepService }}
+  name: meep-loc-serv-{{.MepName}}
+  {{- else }}
   name: meep-loc-serv
+  {{- end }}
   type: ClusterIP
   port: 80
 
@@ -28,14 +41,23 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /{{ .SandboxName }}/location
+        {{- if .IsMepService }}
+        - /{{.SandboxName}}/{{.MepName}}/location
+        {{- else }}
+        - /{{.SandboxName}}/location
+        {{- end }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: {{ .HttpsOnly }}
+    {{- if .IsMepService }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/{{ .SandboxName }}/location(/|$)(.*)$ /location/$2 break;
+      rewrite ^/{{.SandboxName}}/{{.MepName}}/location(/|$)(.*)$ /location/$2 break;
+    {{- else }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/{{.SandboxName}}/location(/|$)(.*)$ /location/$2 break;
+    {{- end }}
     {{- if .AuthEnabled }}
-    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-loc-serv&sbox={{ .SandboxName }}
+    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-loc-serv&sbox={{.SandboxName}}&mep={{.MepName}}
     {{- end }}
   labels: {}
   tls:

--- a/charts/meep-loc-serv/values-template.yaml
+++ b/charts/meep-loc-serv/values-template.yaml
@@ -20,6 +20,12 @@ image:
   env:
     MEEP_SANDBOX_NAME: {{.SandboxName}}
     MEEP_HOST_URL: {{.HostUrl}}
+    {{- if .IsMepService }}
+    MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- range .Env}}
+    {{.}}
+    {{- end}}
 
 service:
   {{- if .IsMepService }}

--- a/charts/meep-rnis/templates/clusterrolebinding.yaml
+++ b/charts/meep-rnis/templates/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ .Release.Namespace }}:{{ .Values.serviceAccount }}"
+  name: "{{ .Release.Namespace }}:{{ template "meep-rnis.fullname" . }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-rnis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   

--- a/charts/meep-rnis/templates/deployment.yaml
+++ b/charts/meep-rnis/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             {{- range $key, $value := .Values.image.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
@@ -51,9 +51,15 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
-        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
-        - name: init-{{ .Values.deployment.dependency }}
+        {{- range $value := .Values.deployment.dependencies.system }}
+        - name: init-system-{{ $value }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
+          command: ['sh', '-c', 'until nslookup {{ $value }}.kube-system ; do echo waiting for {{ $value }}; sleep 0.25; done;']
+        {{- end}}
+        {{- range $value := .Values.deployment.dependencies.sandbox }}
+        - name: init-sandbox-{{ $value }}
+          image: busybox:1.28
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'until nslookup {{ $value }} ; do echo waiting for {{ $value }}; sleep 0.25; done;']
         {{- end}}

--- a/charts/meep-rnis/templates/deployment.yaml
+++ b/charts/meep-rnis/templates/deployment.yaml
@@ -51,8 +51,9 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
+        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
         - name: init-{{ .Values.deployment.dependency }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
-
+        {{- end}}

--- a/charts/meep-rnis/templates/ingress.yaml
+++ b/charts/meep-rnis/templates/ingress.yaml
@@ -1,11 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "meep-rnis.fullname" . -}}
+{{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "meep-rnis.fullname" . }}
+  name: {{ $serviceName }}
   labels:
     app: {{ template "meep-rnis.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/meep-rnis/templates/service.yaml
+++ b/charts/meep-rnis/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "meep-rnis.fullname" . }}
+  name: {{ .Values.service.name }}
   labels:
     app: {{ template "meep-rnis.name" . }}
     chart: {{ template "meep-rnis.chart" . }}

--- a/charts/meep-rnis/templates/serviceaccount.yaml
+++ b/charts/meep-rnis/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-rnis.fullname" . }}

--- a/charts/meep-rnis/values-template.yaml
+++ b/charts/meep-rnis/values-template.yaml
@@ -2,26 +2,39 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-serviceAccount: meep-rnis
-
 deployment:
   replicas: 1
   port: 80
   protocol: TCP
   dependency: kube-dns
+  {{- if .IsMepService }}
+  kubeDnsInitContainerEnabled: false
+  {{- else }}
+  kubeDnsInitContainerEnabled: true
+  {{- end }}
 
 image:
   repository: meep-docker-registry:30001/meep-rnis
   tag: latest
   pullPolicy: Always
   env:
-    MEEP_SANDBOX_NAME: {{ .SandboxName }}
-    MEEP_HOST_URL: {{ .HostUrl }}
     MEAS_REP_UE_PERIODIC_TRIGGER_INTERVAL: 1s
     NR_MEAS_REP_UE_PERIODIC_TRIGGER_INTERVAL: 1s
+    MEEP_SANDBOX_NAME: {{.SandboxName}}
+    MEEP_HOST_URL: {{.HostUrl}}
+    {{- if .IsMepService }}
+    MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- range .Env}}
+    {{.}}
+    {{- end}}
 
 service:
+  {{- if .IsMepService }}
+  name: {{.MepName}}-meep-rnis
+  {{- else }}
   name: meep-rnis
+  {{- end }}
   type: ClusterIP
   port: 80
 
@@ -30,14 +43,23 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /{{ .SandboxName }}/rni
+        {{- if .IsMepService }}
+        - /{{.SandboxName}}/{{.MepName}}/rni
+        {{- else }}
+        - /{{.SandboxName}}/rni
+        {{- end }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: {{ .HttpsOnly }}
+    {{- if .IsMepService }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/{{ .SandboxName }}/rni(/|$)(.*)$ /rni/$2 break;
+      rewrite ^/{{.SandboxName}}/{{.MepName}}/rni(/|$)(.*)$ /rni/$2 break;
+    {{- else }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/{{.SandboxName}}/rni(/|$)(.*)$ /rni/$2 break;
+    {{- end }}
     {{- if .AuthEnabled }}
-    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-rnis&sbox={{ .SandboxName }}
+    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-rnis&sbox={{.SandboxName}}&mep={{.MepName}}
     {{- end }}
   labels: {}
   tls:

--- a/charts/meep-rnis/values-template.yaml
+++ b/charts/meep-rnis/values-template.yaml
@@ -6,12 +6,12 @@ deployment:
   replicas: 1
   port: 80
   protocol: TCP
-  dependency: kube-dns
-  {{- if .IsMepService }}
-  kubeDnsInitContainerEnabled: false
-  {{- else }}
-  kubeDnsInitContainerEnabled: true
-  {{- end }}
+  dependencies:
+    system:
+      {{- if not .IsMepService }}
+      - kube-dns
+      {{- end }}
+    sandbox:
 
 image:
   repository: meep-docker-registry:30001/meep-rnis
@@ -24,6 +24,11 @@ image:
     MEEP_HOST_URL: {{.HostUrl}}
     {{- if .IsMepService }}
     MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- if eq .AppEnablement "local" }}
+    MEEP_APP_ENABLEMENT: {{.MepName}}-meep-app-enablement
+    {{- else if eq .AppEnablement "global" }}
+    MEEP_APP_ENABLEMENT: meep-app-enablement
     {{- end }}
     {{- range .Env}}
     {{.}}

--- a/charts/meep-wais/templates/clusterrolebinding.yaml
+++ b/charts/meep-wais/templates/clusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: "{{ .Release.Namespace }}:{{ .Values.serviceAccount }}"
+  name: "{{ .Release.Namespace }}:{{ template "meep-wais.fullname" . }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-wais.fullname" . }}
   namespace: {{ .Release.Namespace }}
   

--- a/charts/meep-wais/templates/deployment.yaml
+++ b/charts/meep-wais/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             {{- range $key, $value := .Values.image.env }}
             - name: {{ $key }}
-              value: {{ $value }}
+              value: {{ $value | quote }}
             {{- end }}
           {{- if .Values.codecov.enabled}}
           volumeMounts:
@@ -51,9 +51,15 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
-        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
-        - name: init-{{ .Values.deployment.dependency }}
+        {{- range $value := .Values.deployment.dependencies.system }}
+        - name: init-system-{{ $value }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
-          command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
+          command: ['sh', '-c', 'until nslookup {{ $value }}.kube-system ; do echo waiting for {{ $value }}; sleep 0.25; done;']
+        {{- end}}
+        {{- range $value := .Values.deployment.dependencies.sandbox }}
+        - name: init-sandbox-{{ $value }}
+          image: busybox:1.28
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', 'until nslookup {{ $value }} ; do echo waiting for {{ $value }}; sleep 0.25; done;']
         {{- end}}

--- a/charts/meep-wais/templates/deployment.yaml
+++ b/charts/meep-wais/templates/deployment.yaml
@@ -51,8 +51,9 @@ spec:
           {{- end}}
       terminationGracePeriodSeconds: 5
       initContainers:
+        {{- if .Values.deployment.kubeDnsInitContainerEnabled }}
         - name: init-{{ .Values.deployment.dependency }}
           image: busybox:1.28
           imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'until nslookup {{ .Values.deployment.dependency }}.kube-system ; do echo waiting for {{ .Values.deployment.dependency }}; sleep 0.25; done;']
-
+        {{- end}}

--- a/charts/meep-wais/templates/ingress.yaml
+++ b/charts/meep-wais/templates/ingress.yaml
@@ -1,11 +1,10 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := include "meep-wais.fullname" . -}}
+{{- $serviceName := .Values.service.name -}}
 {{- $servicePort := .Values.service.port -}}
-{{- $path := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ template "meep-wais.fullname" . }}
+  name: {{ $serviceName }}
   labels:
     app: {{ template "meep-wais.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/meep-wais/templates/service.yaml
+++ b/charts/meep-wais/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "meep-wais.fullname" . }}
+  name: {{ .Values.service.name }}
   labels:
     app: {{ template "meep-wais.name" . }}
     chart: {{ template "meep-wais.chart" . }}

--- a/charts/meep-wais/templates/serviceaccount.yaml
+++ b/charts/meep-wais/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount }}
+  name: {{ template "meep-wais.fullname" . }}

--- a/charts/meep-wais/values-template.yaml
+++ b/charts/meep-wais/values-template.yaml
@@ -2,24 +2,37 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-serviceAccount: meep-wais
-
 deployment:
   replicas: 1
   port: 80
   protocol: TCP
   dependency: kube-dns
+  {{- if .IsMepService }}
+  kubeDnsInitContainerEnabled: false
+  {{- else }}
+  kubeDnsInitContainerEnabled: true
+  {{- end }}
 
 image:
   repository: meep-docker-registry:30001/meep-wais
   tag: latest
   pullPolicy: Always
   env:
-    MEEP_SANDBOX_NAME: {{ .SandboxName }}
-    MEEP_HOST_URL: {{ .HostUrl }}
+    MEEP_SANDBOX_NAME: {{.SandboxName}}
+    MEEP_HOST_URL: {{.HostUrl}}
+    {{- if .IsMepService }}
+    MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- range .Env}}
+    {{.}}
+    {{- end}}
 
 service:
+  {{- if .IsMepService }}
+  name: {{.MepName}}-meep-wais
+  {{- else }}
   name: meep-wais
+  {{- end }}
   type: ClusterIP
   port: 80
 
@@ -28,14 +41,23 @@ ingress:
   hosts:
     - name: ''
       paths:
-        - /{{ .SandboxName }}/wai
+        {{- if .IsMepService }}
+        - /{{.SandboxName}}/{{.MepName}}/wai
+        {{- else }}
+        - /{{.SandboxName}}/wai
+        {{- end }}
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/force-ssl-redirect: {{ .HttpsOnly }}
+    {{- if .IsMepService }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/{{ .SandboxName }}/wai(/|$)(.*)$ /wai/$2 break;
+      rewrite ^/{{.SandboxName}}/{{.MepName}}/wai(/|$)(.*)$ /wai/$2 break;
+    {{- else }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/{{.SandboxName}}/wai(/|$)(.*)$ /wai/$2 break;
+    {{- end }}
     {{- if .AuthEnabled }}
-    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-wais&sbox={{ .SandboxName }}
+    nginx.ingress.kubernetes.io/auth-url: https://$http_host/auth/v1/authenticate?svc=meep-wais&sbox={{.SandboxName}}&mep={{.MepName}}
     {{- end }}
   labels: {}
   tls:

--- a/charts/meep-wais/values-template.yaml
+++ b/charts/meep-wais/values-template.yaml
@@ -6,12 +6,12 @@ deployment:
   replicas: 1
   port: 80
   protocol: TCP
-  dependency: kube-dns
-  {{- if .IsMepService }}
-  kubeDnsInitContainerEnabled: false
-  {{- else }}
-  kubeDnsInitContainerEnabled: true
-  {{- end }}
+  dependencies:
+    system:
+      {{- if not .IsMepService }}
+      - kube-dns
+      {{- end }}
+    sandbox:
 
 image:
   repository: meep-docker-registry:30001/meep-wais
@@ -22,6 +22,11 @@ image:
     MEEP_HOST_URL: {{.HostUrl}}
     {{- if .IsMepService }}
     MEEP_MEP_NAME: {{.MepName}}
+    {{- end }}
+    {{- if eq .AppEnablement "local" }}
+    MEEP_APP_ENABLEMENT: {{.MepName}}-meep-app-enablement
+    {{- else if eq .AppEnablement "global" }}
+    MEEP_APP_ENABLEMENT: meep-app-enablement
     {{- end }}
     {{- range .Env}}
     {{.}}

--- a/go-apps/meep-app-enablement/server/app-info/app-info.go
+++ b/go-apps/meep-app-enablement/server/app-info/app-info.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	appSupport "github.com/InterDigitalInc/AdvantEDGE/go-apps/meep-app-enablement/server/app-support"
@@ -35,24 +36,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const appInfoBasePath = "/app_info/v1/"
+const appInfoBasePath = "app_info/v1/"
 const appEnablementKey = "app-enablement"
+const defaultMepName = "global"
 const ACTIVE = "ACTIVE"
 const INACTIVE = "INACTIVE"
 
-//const logModuleMSMgmt = "meep-app-enablement"
-//const serviceName = "MEC Service Management"
-
 var redisAddr string = "meep-redis-master.default.svc.cluster.local:6379"
 
-var APP_ENABLEMENT_DB = 5
+var APP_ENABLEMENT_DB = 0
 
+var mutex *sync.Mutex
 var rc *redis.Connector
 var hostUrl *url.URL
 var sandboxName string
-var selfName string
+var mepName string = defaultMepName
 var basePath string
-var appEnablementBaseKey string
+var baseKey string
 
 var expiryTicker *time.Ticker
 
@@ -68,12 +68,9 @@ type FilterParameters struct {
 	appState string
 }
 
-/*func notImplemented(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-        w.WriteHeader(http.StatusNotImplemented)
-}
-*/
-func Init() (err error) {
+func Init(globalMutex *sync.Mutex) (err error) {
+	mutex = globalMutex
+
 	// Retrieve Sandbox name from environment variable
 	sandboxNameEnv := strings.TrimSpace(os.Getenv("MEEP_SANDBOX_NAME"))
 	if sandboxNameEnv != "" {
@@ -94,28 +91,24 @@ func Init() (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
 
-	selfNameEnv := strings.TrimSpace(os.Getenv("MEEP_SELF_NAME"))
-	if selfNameEnv != "" {
-		selfName = selfNameEnv
+	// Get MEP name
+	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
+	if mepNameEnv != "" {
+		mepName = mepNameEnv
 	}
-	//TODO
-	/*
-		if selfName == "" {
-			err = errors.New("MEEP_SELF_NAME env variable not set")
-			log.Error(err.Error())
-			return err
-		}
-	*/
-	//HARDCODE SOMETHING
-	selfName = "mep1"
-	log.Info("MEEP_SELF_NAME: ", selfName)
+	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Set base path
-	basePath = "/" + sandboxName + appInfoBasePath
-	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + selfName
+	if mepName == defaultMepName {
+		basePath = "/" + sandboxName + "/" + appInfoBasePath
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + appInfoBasePath
+	}
+
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + mepName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)
@@ -123,9 +116,7 @@ func Init() (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
-
-	_ = rc.DBFlush(appEnablementBaseKey)
-
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB")
 
 	reInit()
@@ -175,7 +166,7 @@ func getNewInstanceId() (string, error) {
 
 func validateAppInstanceId(appInstanceId string) error {
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		if err != nil {
@@ -214,7 +205,7 @@ func applicationsPOST(w http.ResponseWriter, r *http.Request) {
 	appInfo.AppInstanceId = appInstanceId
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err == nil && len(fields) > 0 {
 		log.Error("AppInstanceId already exists")
@@ -276,7 +267,7 @@ func applicationsAppInstanceIdPUT(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not already exist")
@@ -335,7 +326,7 @@ func applicationsAppInstanceIdGET(w http.ResponseWriter, r *http.Request) {
 
 	appInstanceId := vars["appInstanceId"]
 
-	fields, err := rc.GetEntry(appEnablementBaseKey + ":apps:" + appInstanceId)
+	fields, err := rc.GetEntry(baseKey + ":app:" + appInstanceId + ":info")
 	if err != nil {
 		log.Error(err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -362,29 +353,21 @@ func applicationsAppInstanceIdDELETE(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appInstanceId := vars["appInstanceId"]
 
-	fields, err := rc.GetEntry(appEnablementBaseKey + ":apps:" + appInstanceId)
-	if err == nil && len(fields) > 0 {
-
-		//deletes all the services related to that app instance ID
-		err = msmgmt.AppServicesDELETE(appInstanceId)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-
-		//sends notification for a termination of the application if subscribed for it, send default graceful timeout
-		appSupport.SendAppTerminationNotification(appInstanceId, 0)
-		//sleep to test when sending a termination confirm taht it is processed correctly
-		//time.Sleep(10 * time.Second)
-		err := rc.DelEntry(appEnablementBaseKey + ":apps:" + appInstanceId)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	} else {
+	// Check if App instance exists
+	fields, err := rc.GetEntry(baseKey + ":app:" + appInstanceId + ":info")
+	if err != nil || len(fields) == 0 {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
+	// Delete app instance services
+	_ = msmgmt.AppServicesDELETE(appInstanceId)
+
+	// Send termination notification for graceful termination
+	appSupport.SendAppTerminationNotification(appInstanceId, 0)
+
+	// Flush App instance
+	_ = rc.DBFlush(baseKey + ":app:" + appInstanceId)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -421,7 +404,7 @@ func applicationsGET(w http.ResponseWriter, r *http.Request) {
 	filterParameters.appState = appState
 	applicationInfoList.filterParameters = &filterParameters
 
-	keyName := appEnablementBaseKey + ":apps:*"
+	keyName := baseKey + ":app:*:info"
 
 	err := rc.ForEachEntry(keyName, populateApplicationInfoList, &applicationInfoList)
 	if err != nil {

--- a/go-apps/meep-app-enablement/server/app-support/app-support.go
+++ b/go-apps/meep-app-enablement/server/app-support/app-support.go
@@ -616,7 +616,8 @@ func checkAppTermNotification(appInstanceId string, gracefulTimeout int32, needM
 				//start graceful shutdown timer
 				gracefulTimeoutTicker := time.NewTicker(time.Duration(gracefulTimeout) * time.Second)
 				appTerminationGracefulTimeoutMap[appInstanceId] = gracefulTimeoutTicker
-				key := appEnablementBaseKey + ":apps:" + appInstanceId
+
+				key := baseKey + ":app:" + appInstanceId + ":info"
 				go func() {
 					for range gracefulTimeoutTicker.C {
 						log.Info("Graceful timeout expiry for ", appInstanceId, "---", appTerminationGracefulTimeoutMap[appInstanceId])

--- a/go-apps/meep-app-enablement/server/app-support/app-support.go
+++ b/go-apps/meep-app-enablement/server/app-support/app-support.go
@@ -191,7 +191,7 @@ func applicationsConfirmReadyPOST(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -238,7 +238,7 @@ func applicationsConfirmTerminationPOST(w http.ResponseWriter, r *http.Request) 
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -381,7 +381,7 @@ func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -475,7 +475,7 @@ func applicationsSubscriptionGET(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -499,7 +499,7 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -530,7 +530,7 @@ func applicationsSubscriptionsGET(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := baseKey + ":app:" + appInstanceId + "info"
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")

--- a/go-apps/meep-app-enablement/server/app-support/app-support.go
+++ b/go-apps/meep-app-enablement/server/app-support/app-support.go
@@ -39,9 +39,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const mappsupportBasePath = "/mec_app_support/v1/"
+const mappsupportBasePath = "mec_app_support/v1/"
 const mappsupportKey = "as"
 const appEnablementKey = "app-enablement"
+const defaultMepName = "global"
 const ACTIVE = "ACTIVE"
 const INACTIVE = "INACTIVE"
 const APP_TERMINATION_NOTIFICATION_SUBSCRIPTION_TYPE = "AppTerminationNotificationSubscription"
@@ -54,25 +55,19 @@ var mutex *sync.Mutex
 
 var redisAddr string = "meep-redis-master.default.svc.cluster.local:6379"
 
-var APP_ENABLEMENT_DB = 5
+var APP_ENABLEMENT_DB = 0
 
 var rc *redis.Connector
 var hostUrl *url.URL
 var sandboxName string
-var selfName string
+var mepName string = defaultMepName
 var basePath string
-var appEnablementBaseKey string
+var baseKey string
 
 //var expiryTicker *time.Ticker
 var appTerminationGracefulTimeoutMap = map[string]*time.Ticker{}
 var appTerminationNotificationSubscriptionMap = map[int]*AppTerminationNotificationSubscription{}
 var nextSubscriptionIdAvailable int
-
-/*func notImplemented(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-        w.WriteHeader(http.StatusNotImplemented)
-}
-*/
 
 func Init(globalMutex *sync.Mutex) (err error) {
 	mutex = globalMutex
@@ -98,28 +93,24 @@ func Init(globalMutex *sync.Mutex) (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
 
-	selfNameEnv := strings.TrimSpace(os.Getenv("MEEP_SELF_NAME"))
-	if selfNameEnv != "" {
-		selfName = selfNameEnv
+	// Get MEP name
+	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
+	if mepNameEnv != "" {
+		mepName = mepNameEnv
 	}
-	//TODO
-	/*
-		if selfName == "" {
-			err = errors.New("MEEP_SELF_NAME env variable not set")
-			log.Error(err.Error())
-			return err
-		}
-	*/
-	//HARDCODE SOMETHING
-	selfName = "mep1"
-	log.Info("MEEP_SELF_NAME: ", selfName)
+	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Set base path
-	basePath = "/" + sandboxName + mappsupportBasePath
-	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + selfName
+	if mepName == defaultMepName {
+		basePath = "/" + sandboxName + "/" + mappsupportBasePath
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + mappsupportBasePath
+	}
+
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + mepName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)
@@ -127,21 +118,11 @@ func Init(globalMutex *sync.Mutex) (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
-
-	_ = rc.DBFlush(appEnablementBaseKey)
-
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB")
 
 	reInit()
 
-	/*
-		expiryTicker = time.NewTicker(time.Second)
-		go func() {
-			for range expiryTicker.C {
-				//checkForExpiredSubscriptions()
-			}
-		}()
-	*/
 	return nil
 }
 
@@ -151,7 +132,7 @@ func reInit() {
 	//next available subsId will be overrriden if subscriptions already existed
 	nextSubscriptionIdAvailable = 1
 
-	keyName := appEnablementBaseKey + ":apps:*:" + mappsupportKey + ":subscriptions:" + "*"
+	keyName := baseKey + ":app:*:" + mappsupportKey + ":sub:*"
 	_ = rc.ForEachJSONEntry(keyName, repopulateAppTerminationNotificationSubscriptionMap, nil)
 }
 
@@ -210,7 +191,7 @@ func applicationsConfirmReadyPOST(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -257,7 +238,7 @@ func applicationsConfirmTerminationPOST(w http.ResponseWriter, r *http.Request) 
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -354,7 +335,7 @@ func updateDB(key string, state string) error {
 func updateAllServices(appInstanceId string, state msmgmt.ServiceState) error {
 	var sInfoList msmgmt.ServiceInfoList
 
-	keyName := appEnablementBaseKey + ":apps:" + appInstanceId + ":svcs:*"
+	keyName := baseKey + ":app:" + appInstanceId + ":svc:*"
 
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -366,7 +347,7 @@ func updateAllServices(appInstanceId string, state msmgmt.ServiceState) error {
 	for _, sInfo := range sInfoList.ServiceInfos {
 		serviceId := sInfo.SerInstanceId
 		sInfo.State = &state
-		err = rc.JSONSetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".", msmgmt.ConvertServiceInfoToJson(&sInfo))
+		err = rc.JSONSetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".", msmgmt.ConvertServiceInfoToJson(&sInfo))
 		if err != nil {
 			return err
 		}
@@ -400,7 +381,7 @@ func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -454,8 +435,7 @@ func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 
 	//registration
 	registerAppTerm(&subscription, newSubsId)
-	baseKey := key + ":" + mappsupportKey
-	_ = rc.JSONSetEntry(baseKey+":subscriptions:"+subsIdStr, ".", convertAppTerminationNotificationSubscriptionToJson(&subscription))
+	_ = rc.JSONSetEntry(key+":"+mappsupportKey+":sub:"+subsIdStr, ".", convertAppTerminationNotificationSubscriptionToJson(&subscription))
 
 	jsonResponse, err := json.Marshal(subscription)
 
@@ -495,15 +475,14 @@ func applicationsSubscriptionGET(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
 		http.Error(w, "AppInstanceId does not exist, app is not running", http.StatusBadRequest)
 		return
 	}
-	baseKey := key + ":" + mappsupportKey
-	jsonResponse, _ := rc.JSONGetEntry(baseKey+":subscriptions:"+subIdParamStr, ".")
+	jsonResponse, _ := rc.JSONGetEntry(key+":"+mappsupportKey+":sub:"+subIdParamStr, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -520,7 +499,7 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -528,14 +507,13 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	baseKey := key + ":" + mappsupportKey
-	jsonResponse, _ := rc.JSONGetEntry(baseKey+":subscriptions:"+subIdParamStr, ".")
+	jsonResponse, _ := rc.JSONGetEntry(key+":"+mappsupportKey+":sub:"+subIdParamStr, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	err = rc.JSONDelEntry(baseKey+":subscriptions"+":"+subIdParamStr, ".")
+	err = rc.JSONDelEntry(key+":"+mappsupportKey+":sub:"+subIdParamStr, ".")
 	deregisterAppTermination(subIdParamStr, false)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -552,7 +530,7 @@ func applicationsSubscriptionsGET(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + "info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")

--- a/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
@@ -38,9 +38,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const msmgmtBasePath = "/mec_service_mgmt/v1/"
+const msmgmtBasePath = "mec_service_mgmt/v1/"
 const msmgmtKey = "sm"
 const appEnablementKey = "app-enablement"
+const defaultMepName = "global"
 const SER_AVAILABILITY_NOTIFICATION_SUBSCRIPTION_TYPE = "SerAvailabilityNotificationSubscription"
 const SER_AVAILABILITY_NOTIFICATION_TYPE = "SerAvailabilityNotification"
 
@@ -51,25 +52,19 @@ var mutex *sync.Mutex
 
 var redisAddr string = "meep-redis-master.default.svc.cluster.local:6379"
 
-var APP_ENABLEMENT_DB = 5
+var APP_ENABLEMENT_DB = 0
 
 var rc *redis.Connector
 var hostUrl *url.URL
 var sandboxName string
-var selfName string
+var mepName string = defaultMepName
 var basePath string
-var appEnablementBaseKey string
+var baseKey string
 
 var serAvailabilityNotificationSubscriptionMap = map[int]*SerAvailabilityNotificationSubscription{}
 
 var nextSubscriptionIdAvailable int
 var nextServiceRegistrationIdAvailable int
-
-/*func notImplemented(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-        w.WriteHeader(http.StatusNotImplemented)
-}
-*/
 
 type ServiceInfoList struct {
 	ServiceInfos     []ServiceInfo
@@ -85,13 +80,9 @@ type FilterParameters struct {
 	scopeOfLocality   string
 }
 
-/*func notImplemented(w http.ResponseWriter, r *http.Request) {
-        w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-        w.WriteHeader(http.StatusNotImplemented)
-}
-*/
 func Init(globalMutex *sync.Mutex) (err error) {
 	mutex = globalMutex
+
 	// Retrieve Sandbox name from environment variable
 	sandboxNameEnv := strings.TrimSpace(os.Getenv("MEEP_SANDBOX_NAME"))
 	if sandboxNameEnv != "" {
@@ -113,27 +104,24 @@ func Init(globalMutex *sync.Mutex) (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
 
-	selfNameEnv := strings.TrimSpace(os.Getenv("MEEP_SELF_NAME"))
-	if selfNameEnv != "" {
-		selfName = selfNameEnv
+	// Get MEP name
+	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
+	if mepNameEnv != "" {
+		mepName = mepNameEnv
 	}
-	//TODO
-	/*	if selfName == "" {
-			err = errors.New("MEEP_SELF_NAME env variable not set")
-			log.Error(err.Error())
-			return err
-		}
-	*/
-	//HARDCODE SOMETHING
-	selfName = "mep1"
-	log.Info("MEEP_SELF_NAME: ", selfName)
+	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Set base path
-	basePath = "/" + sandboxName + msmgmtBasePath
-	// Get base store key
-	appEnablementBaseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + selfName
+	if mepName == defaultMepName {
+		basePath = "/" + sandboxName + "/" + msmgmtBasePath
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + msmgmtBasePath
+	}
+
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + appEnablementKey + ":mep:" + mepName
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, APP_ENABLEMENT_DB)
@@ -141,21 +129,11 @@ func Init(globalMutex *sync.Mutex) (err error) {
 		log.Error("Failed connection to Redis DB. Error: ", err)
 		return err
 	}
-
-	_ = rc.DBFlush(appEnablementBaseKey)
-
+	_ = rc.DBFlush(baseKey)
 	log.Info("Connected to Redis DB")
 
 	reInit()
 
-	/*
-	   expiryTicker = time.NewTicker(time.Second)
-	   go func() {
-	           for range expiryTicker.C {
-	                   //checkForExpiredSubscriptions()
-	           }
-	   }()
-	*/
 	return nil
 }
 
@@ -165,10 +143,8 @@ func reInit() {
 	nextSubscriptionIdAvailable = 1
 	nextServiceRegistrationIdAvailable = 1
 
-	baseKey := appEnablementBaseKey + ":apps:*:" + msmgmtKey
-	keyName := baseKey + ":subscriptions:" + "*"
+	keyName := baseKey + ":app:*:" + msmgmtKey + ":sub:*"
 	_ = rc.ForEachJSONEntry(keyName, repopulateSerAvailabilityNotificationSubscriptionMap, nil)
-
 }
 
 // Run - Start Service Mgmt
@@ -194,9 +170,6 @@ func repopulateSerAvailabilityNotificationSubscriptionMap(key string, jsonInfo s
 	selfUrl := strings.Split(subscription.Links.Self.Href, "/")
 	subsIdStr := selfUrl[len(selfUrl)-1]
 	subsId, _ := strconv.Atoi(subsIdStr)
-
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	serAvailabilityNotificationSubscriptionMap[subsId] = &subscription
 
@@ -265,7 +238,7 @@ func appServicesGETByAppInstanceId(w http.ResponseWriter, r *http.Request, appIn
 	filterParameters.scopeOfLocality = scopeOfLocality
 	sInfoList.filterParameters = &filterParameters
 
-	keyName := appEnablementBaseKey + ":apps:" + appInstanceId + ":svcs:*"
+	keyName := baseKey + ":app:" + appInstanceId + ":svc:*"
 	err := rc.ForEachJSONEntry(keyName, populateServiceInfoList, &sInfoList)
 	if err != nil {
 		log.Error(err.Error())
@@ -285,7 +258,7 @@ func appServicesGETByAppInstanceId(w http.ResponseWriter, r *http.Request, appIn
 
 func validateAppInstanceId(appInstanceId string) error {
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		if err != nil {
@@ -387,10 +360,11 @@ func populateServiceInfoList(key string, jsonInfo string, sInfoList interface{})
 func appServicesPOST(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	log.Info("appServicesPOST")
-
-	//var response InlineCircleNotificationSubscription
 	vars := mux.Vars(r)
 	appInstanceId := vars["appInstanceId"]
+
+	mutex.Lock()
+	defer mutex.Unlock()
 
 	err := validateAppInstanceId(appInstanceId)
 	if err != nil {
@@ -452,9 +426,6 @@ func deregisterService(appInstanceId string, serviceId string) error {
 
 func registerService(appInstanceId string, sInfoPost *ServiceInfoPost) (*ServiceInfo, error) {
 
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	newServiceId := nextServiceRegistrationIdAvailable
 	nextServiceRegistrationIdAvailable++
 	serviceId := strconv.Itoa(newServiceId)
@@ -485,7 +456,7 @@ func updateServicePost(appInstanceId string, sInfoPost *ServiceInfoPost, service
 		return nil, err
 	}
 
-	err = rc.JSONSetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".", ConvertServiceInfoToJson(sInfo))
+	err = rc.JSONSetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".", ConvertServiceInfoToJson(sInfo))
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +481,7 @@ func updateServicePut(appInstanceId string, sInfoPut *ServiceInfo, serviceId str
 		defer mutex.Unlock()
 	}
 
-	err := rc.JSONSetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".", ConvertServiceInfoToJson(sInfoPut))
+	err := rc.JSONSetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".", ConvertServiceInfoToJson(sInfoPut))
 	if err != nil {
 		return nil, err
 	}
@@ -671,19 +642,22 @@ func appServicesByIdDELETE(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 	serviceId := vars["serviceId"]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	err := validateAppInstanceId(appInstanceId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	jsonResponse, _ := rc.JSONGetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".")
+	jsonResponse, _ := rc.JSONGetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	err = rc.JSONDelEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".")
+	err = rc.JSONDelEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -739,7 +713,7 @@ func appServicesByIdGET(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResponse, _ := rc.JSONGetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".")
+	jsonResponse, _ := rc.JSONGetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -758,6 +732,9 @@ func appServicesByIdPUT(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 	serviceId := vars["serviceId"]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	err := validateAppInstanceId(appInstanceId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -765,7 +742,7 @@ func appServicesByIdPUT(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//find previous values
-	sInfoJson, _ := rc.JSONGetEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+serviceId, ".")
+	sInfoJson, _ := rc.JSONGetEntry(baseKey+":app:"+appInstanceId+":svc:"+serviceId, ".")
 	if sInfoJson == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -851,7 +828,7 @@ func servicesByIdGET(w http.ResponseWriter, r *http.Request) {
 
 	var sInfoList ServiceInfoList
 
-	keyName := appEnablementBaseKey + ":apps:*:svcs:" + serviceId
+	keyName := baseKey + ":app:*:svc:" + serviceId
 	err := rc.ForEachJSONEntry(keyName, populateServiceInfoList, &sInfoList)
 	if err != nil {
 		log.Error(err.Error())
@@ -883,14 +860,15 @@ func servicesGET(w http.ResponseWriter, r *http.Request) {
 }
 
 func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
-
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-
 	vars := mux.Vars(r)
 	appInstanceId := vars["appInstanceId"]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -956,8 +934,7 @@ func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 
 	//registration
 	registerSerAvailability(&subscription, newSubsId)
-	baseKey := key + ":" + msmgmtKey
-	_ = rc.JSONSetEntry(baseKey+":subscriptions:"+subsIdStr, ".", convertSerAvailabilityNotificationSubscriptionToJson(&subscription))
+	_ = rc.JSONSetEntry(key+":"+msmgmtKey+":sub:"+subsIdStr, ".", convertSerAvailabilityNotificationSubscriptionToJson(&subscription))
 
 	jsonResponse, err := json.Marshal(subscription)
 
@@ -972,20 +949,12 @@ func applicationsSubscriptionsPOST(w http.ResponseWriter, r *http.Request) {
 }
 
 func registerSerAvailability(subscription *SerAvailabilityNotificationSubscription, subsId int) {
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	serAvailabilityNotificationSubscriptionMap[subsId] = subscription
 	log.Info("New registration: ", subsId, " type: ", SER_AVAILABILITY_NOTIFICATION_SUBSCRIPTION_TYPE)
 }
 
-func deregisterSerAvailability(subsIdStr string, mutexTaken bool) {
+func deregisterSerAvailability(subsIdStr string) {
 	subsId, _ := strconv.Atoi(subsIdStr)
-	if !mutexTaken {
-		mutex.Lock()
-		defer mutex.Unlock()
-	}
-
 	serAvailabilityNotificationSubscriptionMap[subsId] = nil
 	log.Info("Deregistration: ", subsId, " type: ", SER_AVAILABILITY_NOTIFICATION_SUBSCRIPTION_TYPE)
 }
@@ -997,15 +966,14 @@ func applicationsSubscriptionGET(w http.ResponseWriter, r *http.Request) {
 	appInstanceId := vars["appInstanceId"]
 
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
 		http.Error(w, "AppInstanceId does not exist, app is not running", http.StatusBadRequest)
 		return
 	}
-	baseKey := key + ":" + msmgmtKey
-	jsonResponse, _ := rc.JSONGetEntry(baseKey+":subscriptions:"+subIdParamStr, ".")
+	jsonResponse, _ := rc.JSONGetEntry(key+":"+msmgmtKey+":sub:"+subIdParamStr, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
@@ -1021,8 +989,11 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 	subIdParamStr := vars["subscriptionId"]
 	appInstanceId := vars["appInstanceId"]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -1030,15 +1001,14 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	baseKey := key + ":" + msmgmtKey
-	jsonResponse, _ := rc.JSONGetEntry(baseKey+":subscriptions:"+subIdParamStr, ".")
+	jsonResponse, _ := rc.JSONGetEntry(key+":"+msmgmtKey+":sub:"+subIdParamStr, ".")
 	if jsonResponse == "" {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 
-	err = rc.JSONDelEntry(baseKey+":subscriptions"+":"+subIdParamStr, ".")
-	deregisterSerAvailability(subIdParamStr, false)
+	err = rc.JSONDelEntry(key+":"+msmgmtKey+":sub:"+subIdParamStr, ".")
+	deregisterSerAvailability(subIdParamStr)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1049,12 +1019,14 @@ func applicationsSubscriptionDELETE(w http.ResponseWriter, r *http.Request) {
 
 func applicationsSubscriptionsGET(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-
 	vars := mux.Vars(r)
 	appInstanceId := vars["appInstanceId"]
 
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	//check if entry exist for the application in the DB
-	key := appEnablementBaseKey + ":apps:" + appInstanceId
+	key := baseKey + ":app:" + appInstanceId + ":info"
 	fields, err := rc.GetEntry(key)
 	if err != nil || len(fields) == 0 {
 		log.Error("AppInstanceId does not exist, app is not running")
@@ -1072,9 +1044,6 @@ func applicationsSubscriptionsGET(w http.ResponseWriter, r *http.Request) {
 	subscriptionLinkList.Links = link
 
 	//loop through all different types of subscription
-
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	//loop through appTerm map
 	for _, serAvailSubscription := range serAvailabilityNotificationSubscriptionMap {

--- a/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
@@ -672,21 +672,21 @@ func appServicesByIdDELETE(w http.ResponseWriter, r *http.Request) {
 
 }
 
+// Delete all services
 func AppServicesDELETE(appInstanceId string) error {
 	log.Info("AppServicesDELETE")
 
 	var sInfoList ServiceInfoList
 
-	keyName := appEnablementBaseKey + ":apps:" + appInstanceId + ":svcs:*"
-
-	err := rc.ForEachJSONEntry(keyName, populateServiceInfoList, &sInfoList)
+	key := baseKey + ":app:" + appInstanceId + ":svc:*"
+	err := rc.ForEachJSONEntry(key, populateServiceInfoList, &sInfoList)
 	if err != nil {
 		log.Error(err.Error())
 		return err
 	}
 
 	for _, sInfo := range sInfoList.ServiceInfos {
-		err = rc.JSONDelEntry(appEnablementBaseKey+":apps:"+appInstanceId+":svcs:"+sInfo.SerInstanceId, ".")
+		err = rc.JSONDelEntry(baseKey+":app:"+appInstanceId+":svc:"+sInfo.SerInstanceId, ".")
 		if err != nil {
 			log.Error(err.Error())
 			return err

--- a/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
+++ b/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
@@ -268,7 +268,7 @@ func processActiveScenarioUpdate() {
 		}
 		if !found {
 			sbi.updateUserInfoCB(prevUeName, "", "", nil, nil)
-			log.Info("Ue removed : ", prevUeName)
+			// log.Info("Ue removed : ", prevUeName)
 		}
 	}
 

--- a/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
+++ b/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
@@ -44,6 +44,7 @@ type SbiCfg struct {
 
 type LocServSbi struct {
 	sandboxName             string
+	localityEnabled         bool
 	locality                map[string]bool
 	mqLocal                 *mq.MsgQueue
 	handlerId               int
@@ -73,9 +74,14 @@ func Init(cfg SbiCfg) (err error) {
 	sbi.cleanUpCB = cfg.CleanUpCb
 
 	// Fill locality map
-	sbi.locality = make(map[string]bool)
-	for _, locality := range cfg.Locality {
-		sbi.locality[locality] = true
+	if len(cfg.Locality) > 0 {
+		sbi.locality = make(map[string]bool)
+		for _, locality := range cfg.Locality {
+			sbi.locality[locality] = true
+		}
+		sbi.localityEnabled = true
+	} else {
+		sbi.localityEnabled = false
 	}
 
 	// Create message queue
@@ -404,6 +410,10 @@ func isUeConnected(name string) bool {
 }
 
 func isInLocality(zone string) bool {
-	_, found := sbi.locality[zone]
-	return found
+	if sbi.localityEnabled {
+		if _, found := sbi.locality[zone]; !found {
+			return false
+		}
+	}
+	return true
 }

--- a/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
+++ b/go-apps/meep-loc-serv/sbi/loc-serv-sbi.go
@@ -300,13 +300,8 @@ func getNetworkLocation(name string) (zone string, netLoc string, err error) {
 		err = errors.New("Error getting context for: " + name)
 		return
 	}
-	nodeCtx, ok := ctx.(*mod.NodeContext)
-	if !ok {
-		err = errors.New("Error casting context for: " + name)
-		return
-	}
-	zone = nodeCtx.Parents[mod.Zone]
-	netLoc = nodeCtx.Parents[mod.NetLoc]
+	zone = ctx.Parents[mod.Zone]
+	netLoc = ctx.Parents[mod.NetLoc]
 	return zone, netLoc, nil
 }
 

--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -207,6 +207,7 @@ func Init() (err error) {
 	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Get App Enablement URL
+	appEnablementEnabled = false
 	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
 	if appEnablementEnv != "" {
 		appEnablementUrl = "http://" + appEnablementEnv

--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -155,7 +155,7 @@ var sandboxName string
 var mepName string = defaultMepName
 var scopeOfLocality string = defaultScopeOfLocality
 var consumedLocalOnly bool = defaultConsumedLocalOnly
-var locality []string = []string{}
+var locality []string
 var basePath string
 var baseKey string
 var mutex sync.Mutex
@@ -221,7 +221,7 @@ func Init() (err error) {
 	// Get local consumption
 	consumedLocalOnlyEnv := strings.TrimSpace(os.Getenv("MEEP_CONSUMED_LOCAL_ONLY"))
 	if consumedLocalOnlyEnv != "" {
-		value, err := strconv.ParseBool("true")
+		value, err := strconv.ParseBool(consumedLocalOnlyEnv)
 		if err == nil {
 			consumedLocalOnly = value
 		}
@@ -274,6 +274,7 @@ func Init() (err error) {
 	sbiCfg := sbi.SbiCfg{
 		SandboxName:    sandboxName,
 		RedisAddr:      redisAddr,
+		Locality:       locality,
 		UserInfoCb:     updateUserInfo,
 		ZoneInfoCb:     updateZoneInfo,
 		ApInfoCb:       updateAccessPointInfo,

--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -103,13 +103,9 @@ var userSubscriptionTransferringMap = map[int]string{}
 var userSubscriptionMap = map[int]string{}
 
 var zoneStatusSubscriptionMap = map[int]*ZoneStatusCheck{}
-
 var distanceSubscriptionMap = map[int]*DistanceCheck{}
-
 var periodicTicker *time.Ticker
-
 var areaCircleSubscriptionMap = map[int]*AreaCircleCheck{}
-
 var periodicSubscriptionMap = map[int]*PeriodicCheck{}
 
 var addressConnectedMap = map[string]bool{}
@@ -163,20 +159,19 @@ var mutex sync.Mutex
 var gisAppClient *gisClient.APIClient
 var gisAppClientUrl string = "http://meep-gis-engine"
 
-//MEC011 section begin
 const serviceAppName = "Location"
 const serviceAppVersion = "2.1.1"
 
 var serviceAppInstanceId string
 
-var appEnablementClientUrl string = "http://meep-app-enablement"
-var appEnablementSupport bool = false
-var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
-var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementUrl string
+var appEnablementEnabled bool
 var sendAppTerminationWhenDone bool = false
-var retryAppEnablementTicker *time.Ticker
+var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
+var appEnablementAppInfoClient *appInfoClient.APIClient
 
-//MEC011 section end
+var registrationTicker *time.Ticker
 
 // Init - Location Service initialization
 func Init() (err error) {
@@ -202,7 +197,7 @@ func Init() (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
 
 	// Get MEP name
 	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
@@ -210,6 +205,14 @@ func Init() (err error) {
 		mepName = mepNameEnv
 	}
 	log.Info("MEEP_MEP_NAME: ", mepName)
+
+	// Get App Enablement URL
+	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
+	if appEnablementEnv != "" {
+		appEnablementUrl = "http://" + appEnablementEnv
+		appEnablementEnabled = true
+	}
+	log.Info("MEEP_APP_ENABLEMENT: ", appEnablementUrl)
 
 	// Get scope of locality
 	scopeOfLocalityEnv := strings.TrimSpace(os.Getenv("MEEP_SCOPE_OF_LOCALITY"))
@@ -235,14 +238,15 @@ func Init() (err error) {
 	}
 	log.Info("MEEP_LOCALITY: ", locality)
 
-	// Set base path & base storage key
-	if mepName != "" {
-		basePath = "/" + sandboxName + "/" + mepName + "/" + LocServBasePath
-		baseKey = dkm.GetKeyRoot(sandboxName) + locServKey + ":mep:" + mepName + ":"
-	} else {
+	// Set base path
+	if mepName == defaultMepName {
 		basePath = "/" + sandboxName + "/" + LocServBasePath
-		baseKey = dkm.GetKeyRoot(sandboxName) + locServKey + ":mep-global:"
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + LocServBasePath
 	}
+
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + locServKey + ":mep:" + mepName + ":"
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, LOC_SERV_DB)
@@ -288,58 +292,45 @@ func Init() (err error) {
 	}
 	log.Info("SBI Initialized")
 
-	//register using MEC011
-	if appEnablementSupport {
-		//delay startup on purpose to give time for appEnablement pod to come up (if all coming up at the same time)
-		time.Sleep(2 * time.Second)
+	// Create App Enablement REST clients
+	if appEnablementEnabled {
+		// Create App Info client
+		appInfoClientCfg := appInfoClient.NewConfiguration()
+		appInfoClientCfg.BasePath = appEnablementUrl + "/app_info/v1"
+		appEnablementAppInfoClient = appInfoClient.NewAPIClient(appInfoClientCfg)
+		if appEnablementAppInfoClient == nil {
+			return errors.New("Failed to create App Info REST API client")
+		}
 
-		retryAppEnablementTicker = time.NewTicker(time.Second)
-		go func() {
-			mecAppReadySent := false
-			registrationSent := false
-			for range retryAppEnablementTicker.C {
-				if serviceAppInstanceId == "" {
-					serviceAppInstanceId = getAppInstanceId(serviceAppName, serviceAppVersion)
-				}
-				if serviceAppInstanceId != "" {
-					//sending app is ready
-					if !mecAppReadySent {
-						err := appEnablementMecAppReady(serviceAppInstanceId)
-						if err != nil {
-							log.Error("Failure when sending the MecAppReady message, keep trying. Error: ", err)
-							continue
-						} else {
-							mecAppReadySent = true
-						}
-					}
-					if !registrationSent {
-						err := appEnablementRegistration(serviceAppInstanceId, serviceAppName, serviceAppVersion)
-						if err != nil {
-							log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
-							continue
-						} else {
-							registrationSent = true
-						}
-						/*						err = appEnablementAppSupportSubscribe(serviceAppInstanceId)
-												if err != nil {
-													log.Error("Failed to subscribe to graceful termination. Error: ", err)
-												}
-												sendAppTerminationWhenDone = true
-						*/
-					}
-					if mecAppReadySent && registrationSent {
-						retryAppEnablementTicker.Stop()
-					}
-				}
-			}
-		}()
+		// Create App Support client
+		appSupportClientCfg := appSupportClient.NewConfiguration()
+		appSupportClientCfg.BasePath = appEnablementUrl + "/mec_app_support/v1"
+		appEnablementAppSupportClient = appSupportClient.NewAPIClient(appSupportClientCfg)
+		if appEnablementAppSupportClient == nil {
+			return errors.New("Failed to create App Enablement App Support REST API client")
+		}
+
+		// Create Service Management client
+		srvMgmtClientCfg := srvMgmtClient.NewConfiguration()
+		srvMgmtClientCfg.BasePath = appEnablementUrl + "/mec_service_mgmt/v1"
+		appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(srvMgmtClientCfg)
+		if appEnablementSrvMgmtClient == nil {
+			return errors.New("Failed to create App Enablement Service Management REST API client")
+		}
 	}
 
+	log.Info("Location Service successfully initialized")
 	return nil
 }
 
 // Run - Start Location Service
 func Run() (err error) {
+
+	// Start MEC Service registration ticker
+	if appEnablementEnabled {
+		startRegistrationTicker()
+	}
+
 	periodicTicker = time.NewTicker(time.Second)
 	go func() {
 		for range periodicTicker.C {
@@ -354,99 +345,107 @@ func Run() (err error) {
 
 // Stop - Stop Location
 func Stop() (err error) {
-	periodicTicker.Stop()
-	err = sbi.Stop()
-	if err != nil {
-		return err
-	}
-	if appEnablementSupport {
-		retryAppEnablementTicker.Stop()
-
+	// Stop MEC Service registration ticker
+	if appEnablementEnabled {
+		stopRegistrationTicker()
 		if sendAppTerminationWhenDone {
-			err = appEnablementMecAppTermination(serviceAppInstanceId)
+			err = sendTerminationConfirmation(serviceAppInstanceId)
 			if err != nil {
 				return err
 			}
 		}
 	}
-	return nil
-}
 
-func appEnablementMecAppReady(appInstanceId string) error {
-	appEnablementAppSupportClientCfg := appSupportClient.NewConfiguration()
-	appEnablementAppSupportClientCfg.BasePath = appEnablementClientUrl + "/mec_app_support/v1"
-
-	appEnablementAppSupportClient = appSupportClient.NewAPIClient(appEnablementAppSupportClientCfg)
-	if appEnablementAppSupportClient == nil {
-		log.Error("Failed to create App Enablement App Support REST API client: ", appEnablementAppSupportClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement AppSupport REST API client")
-		return err
-	}
-	var appReady appSupportClient.AppReadyConfirmation
-	//indication
-	indication := appSupportClient.READY_ReadyIndicationType
-	appReady.Indication = &indication
-	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
+	periodicTicker.Stop()
+	err = sbi.Stop()
 	if err != nil {
-		log.Error("Failed to send a ready confirm acknowlegement: ", err)
 		return err
 	}
 	return nil
 }
 
-func appEnablementMecAppTermination(appInstanceId string) error {
+func startRegistrationTicker() {
+	// Wait a few seconds to allow App Enablement Service to start.
+	// This is done to avoid the default 20 second TCP socket connect timeout
+	// if the App Enablement Service is not yet running.
+	log.Info("Waiting for App Enablement Service to start")
+	time.Sleep(5 * time.Second)
 
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
-	}
-	var appTermination appSupportClient.AppTerminationConfirmation
-	//operation action
-	operationAction := appSupportClient.TERMINATING_OperationActionType
-	appTermination.OperationAction = &operationAction
-	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
-	if err != nil {
-		log.Error("Failed to send a confirm termination acknowlegement: ", err)
-		return err
-	}
-	return nil
+	go func() {
+		mecAppReadySent := false
+		// registrationSent := false
+		for range registrationTicker.C {
+			// Get Application instance ID if not already available
+			if serviceAppInstanceId == "" {
+				var err error
+				serviceAppInstanceId, err = getAppInstanceId(serviceAppName, serviceAppVersion)
+				if err != nil || serviceAppInstanceId == "" {
+					continue
+				}
+			}
+
+			// Send App Ready message
+			if !mecAppReadySent {
+				err := sendReadyConfirmation(serviceAppInstanceId)
+				if err != nil {
+					log.Error("Failure when sending the MecAppReady message. Error: ", err)
+					continue
+				}
+				mecAppReadySent = true
+			}
+
+			// Register service instance
+			// if !registrationSent {
+			err := registerService(serviceAppInstanceId, serviceAppName, serviceAppVersion)
+			if err != nil {
+				log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
+				continue
+			}
+			// 	registrationSent = true
+			// }
+
+			// // Register for graceful termination
+			// if !subscriptionSent {
+			// 	err = subscribeAppTermination(serviceAppInstanceId)
+			// 	if err != nil {
+			// 		log.Error("Failed to subscribe to graceful termination. Error: ", err)
+			// 		continue
+			// 	}
+			// 	sendAppTerminationWhenDone = true
+			// 	subscriptionSent = true
+			// }
+
+			// Registration complete
+			log.Info("Successfully registered with App Enablement Service")
+			stopRegistrationTicker()
+			return
+		}
+	}()
 }
 
-func getAppInstanceId(appName string, appVersion string) string {
-	//var client *appInfoClient.APIClient
-	appInfoClientCfg := appInfoClient.NewConfiguration()
-	appInfoClientCfg.BasePath = appEnablementClientUrl + "/app_info/v1"
-
-	client := appInfoClient.NewAPIClient(appInfoClientCfg)
-	if client == nil {
-		log.Error("Failed to create App Info REST API client: ", appInfoClientCfg.BasePath)
-		return ""
+func stopRegistrationTicker() {
+	if registrationTicker != nil {
+		log.Info("Stopping App Enablement registration ticker")
+		registrationTicker.Stop()
+		registrationTicker = nil
 	}
+}
+
+func getAppInstanceId(appName string, appVersion string) (id string, err error) {
 	var appInfo appInfoClient.ApplicationInfo
 	appInfo.AppName = appName
 	appInfo.Version = appVersion
 	state := appInfoClient.INACTIVE_ApplicationState
 	appInfo.State = &state
-	appInfoResponse, _, err := client.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
+	appInfoResponse, _, err := appEnablementAppInfoClient.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
 	if err != nil {
-		log.Error("Failed to communicate with app enablement service: ", err)
-		return ""
+		log.Error("Failed to get App Instance ID with error: ", err)
+		return "", err
 	}
-	return appInfoResponse.AppInstanceId
+	return appInfoResponse.AppInstanceId, nil
 }
 
-func appEnablementRegistration(appInstanceId string, appName string, appVersion string) error {
-
-	appEnablementSrvMgmtClientCfg := srvMgmtClient.NewConfiguration()
-	appEnablementSrvMgmtClientCfg.BasePath = appEnablementClientUrl + "/mec_service_mgmt/v1"
-
-	appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(appEnablementSrvMgmtClientCfg)
-	if appEnablementSrvMgmtClient == nil {
-		log.Error("Failed to create App Enablement Srv Mgmt REST API client: ", appEnablementSrvMgmtClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement Srv Mgmt REST API client")
-		return err
-	}
+func registerService(appInstanceId string, appName string, appVersion string) error {
 	var srvInfo srvMgmtClient.ServiceInfoPost
 	//serName
 	srvInfo.SerName = appName
@@ -482,11 +481,11 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	srvInfo.SerCategory = &category
 
 	//scopeOfLocality
-	scopeOfLocality := srvMgmtClient.MEC_SYSTEM_LocalityType
-	srvInfo.ScopeOfLocality = &scopeOfLocality
+	localityType := srvMgmtClient.LocalityType(scopeOfLocality)
+	srvInfo.ScopeOfLocality = &localityType
 
 	//consumedLocalOnly
-	srvInfo.ConsumedLocalOnly = false
+	srvInfo.ConsumedLocalOnly = consumedLocalOnly
 
 	appServicesPostResponse, _, err := appEnablementSrvMgmtClient.AppServicesApi.AppServicesPOST(context.TODO(), srvInfo, appInstanceId)
 	if err != nil {
@@ -497,28 +496,42 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	return nil
 }
 
-/*
-func appEnablementAppSupportSubscribe(appInstanceId string) error {
-
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
-	}
-	var appTerminationNotificationSubscription appSupportClient.AppTerminationNotificationSubscription
-	//operation action
-	appTerminationNotificationSubscription.SubscriptionType = "AppTerminationNotificationSubscription"
-	appTerminationNotificationSubscription.AppInstanceId = appInstanceId
-	appTerminationNotificationSubscription.CallbackReference = hostUrl.String() + basePath
-
-	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), appTerminationNotificationSubscription, appInstanceId)
+func sendReadyConfirmation(appInstanceId string) error {
+	var appReady appSupportClient.AppReadyConfirmation
+	indication := appSupportClient.READY_ReadyIndicationType
+	appReady.Indication = &indication
+	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
 	if err != nil {
-		log.Error("Failed to register to App Support subscription: ", err)
+		log.Error("Failed to send a ready confirm acknowlegement: ", err)
 		return err
 	}
 	return nil
 }
-*/
+
+func sendTerminationConfirmation(appInstanceId string) error {
+	var appTermination appSupportClient.AppTerminationConfirmation
+	operationAction := appSupportClient.TERMINATING_OperationActionType
+	appTermination.OperationAction = &operationAction
+	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
+	if err != nil {
+		log.Error("Failed to send a confirm termination acknowlegement: ", err)
+		return err
+	}
+	return nil
+}
+
+// func subscribeAppTermination(appInstanceId string) error {
+// 	var subscription appSupportClient.AppTerminationNotificationSubscription
+// 	subscription.SubscriptionType = "AppTerminationNotificationSubscription"
+// 	subscription.AppInstanceId = appInstanceId
+// 	subscription.CallbackReference = hostUrl.String() + basePath
+// 	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), subscription, appInstanceId)
+// 	if err != nil {
+// 		log.Error("Failed to register to App Support subscription: ", err)
+// 		return err
+// 	}
+// 	return nil
+// }
 
 func deregisterZoneStatus(subsIdStr string) {
 	subsId, err := strconv.Atoi(subsIdStr)

--- a/go-apps/meep-loc-serv/server/loc-serv.go
+++ b/go-apps/meep-loc-serv/server/loc-serv.go
@@ -366,12 +366,20 @@ func Stop() (err error) {
 }
 
 func startRegistrationTicker() {
+	// Make sure ticker is not running
+	if registrationTicker != nil {
+		log.Warn("Registration ticker already running")
+		return
+	}
+
 	// Wait a few seconds to allow App Enablement Service to start.
 	// This is done to avoid the default 20 second TCP socket connect timeout
 	// if the App Enablement Service is not yet running.
 	log.Info("Waiting for App Enablement Service to start")
 	time.Sleep(5 * time.Second)
 
+	// Start registration ticker
+	registrationTicker = time.NewTicker(5 * time.Second)
 	go func() {
 		mecAppReadySent := false
 		// registrationSent := false

--- a/go-apps/meep-mg-manager/server/mg-manager.go
+++ b/go-apps/meep-mg-manager/server/mg-manager.go
@@ -400,18 +400,13 @@ func processScenario(model *mod.Model) error {
 			err := errors.New("Error getting context for process: " + name)
 			return err
 		}
-		nodeCtx, ok := ctx.(*mod.NodeContext)
-		if !ok {
-			err := errors.New("Error casting context for process: " + name)
-			return err
-		}
 
 		// Get network element from list or create new one if it does not exist
 		netElem := getNetElem(proc.Name)
 
 		// Set current physical & network location and network locations in range
-		netElem.phyLoc = nodeCtx.Parents[mod.PhyLoc]
-		netElem.netLoc = nodeCtx.Parents[mod.NetLoc]
+		netElem.phyLoc = ctx.Parents[mod.PhyLoc]
+		netElem.netLoc = ctx.Parents[mod.NetLoc]
 		phyLocNode := model.GetNode(netElem.phyLoc)
 		if phyLocNode == nil {
 			err := errors.New("Error finding physical location: " + netElem.phyLoc)

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -203,7 +203,7 @@ const serviceAppVersion = "2.1.1"
 var serviceAppInstanceId string
 
 var appEnablementUrl string
-var appEnablementEnabled bool = false
+var appEnablementEnabled bool
 var sendAppTerminationWhenDone bool = false
 var appEnablementAppSupportClient *appSupportClient.APIClient
 var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
@@ -250,6 +250,7 @@ func Init() (err error) {
 	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Get App Enablement URL
+	appEnablementEnabled = false
 	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
 	if appEnablementEnv != "" {
 		appEnablementUrl = "http://" + appEnablementEnv

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -44,10 +44,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const rnisBasePath = "/rni/v2/"
-const rnisKey = "rnis:"
+const rnisBasePath = "rni/v2/"
+const rnisKey = "rnis"
 const logModuleRNIS = "meep-rnis"
 const serviceName = "RNI Service"
+const defaultMepName = "global"
+const defaultScopeOfLocality = "MEC_SYSTEM"
+const defaultConsumedLocalOnly = true
 
 const (
 	notifCellChange = "CellChangeNotification"
@@ -95,11 +98,15 @@ const RAB_REL_NOTIFICATION = "RabRelNotification"
 const MEAS_REP_UE_NOTIFICATION = "MeasRepUeNotification"
 const NR_MEAS_REP_UE_NOTIFICATION = "NrMeasRepUeNotification"
 
-var RNIS_DB = 5
+var RNIS_DB = 0
 
 var rc *redis.Connector
 var hostUrl *url.URL
 var sandboxName string
+var mepName string = defaultMepName
+var scopeOfLocality string = defaultScopeOfLocality
+var consumedLocalOnly bool = defaultConsumedLocalOnly
+var locality []string
 var basePath string
 var baseKey string
 var mutex sync.Mutex
@@ -190,20 +197,19 @@ type PlmnInfoResp struct {
 	PlmnInfoList []PlmnInfo
 }
 
-//MEC011 section begin
 const serviceAppName = "RNI"
 const serviceAppVersion = "2.1.1"
 
 var serviceAppInstanceId string
 
-var appEnablementClientUrl string = "http://meep-app-enablement"
-var appEnablementSupport bool = true
-var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
-var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementUrl string
+var appEnablementEnabled bool = false
 var sendAppTerminationWhenDone bool = false
-var retryAppEnablementTicker *time.Ticker
+var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
+var appEnablementAppInfoClient *appInfoClient.APIClient
 
-//MEC011 section end
+var registrationTicker *time.Ticker
 
 func notImplemented(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
@@ -234,14 +240,56 @@ func Init() (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
+
+	// Get MEP name
+	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
+	if mepNameEnv != "" {
+		mepName = mepNameEnv
+	}
+	log.Info("MEEP_MEP_NAME: ", mepName)
+
+	// Get App Enablement URL
+	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
+	if appEnablementEnv != "" {
+		appEnablementUrl = "http://" + appEnablementEnv
+		appEnablementEnabled = true
+	}
+	log.Info("MEEP_APP_ENABLEMENT: ", appEnablementUrl)
+
+	// Get scope of locality
+	scopeOfLocalityEnv := strings.TrimSpace(os.Getenv("MEEP_SCOPE_OF_LOCALITY"))
+	if scopeOfLocalityEnv != "" {
+		scopeOfLocality = scopeOfLocalityEnv
+	}
+	log.Info("MEEP_SCOPE_OF_LOCALITY: ", scopeOfLocality)
+
+	// Get local consumption
+	consumedLocalOnlyEnv := strings.TrimSpace(os.Getenv("MEEP_CONSUMED_LOCAL_ONLY"))
+	if consumedLocalOnlyEnv != "" {
+		value, err := strconv.ParseBool(consumedLocalOnlyEnv)
+		if err == nil {
+			consumedLocalOnly = value
+		}
+	}
+	log.Info("MEEP_CONSUMED_LOCAL_ONLY: ", consumedLocalOnly)
+
+	// Get locality
+	localityEnv := strings.TrimSpace(os.Getenv("MEEP_LOCALITY"))
+	if localityEnv != "" {
+		locality = strings.Split(localityEnv, ":")
+	}
+	log.Info("MEEP_LOCALITY: ", locality)
 
 	// Set base path
-	basePath = "/" + sandboxName + rnisBasePath
+	if mepName == defaultMepName {
+		basePath = "/" + sandboxName + "/" + rnisBasePath
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + rnisBasePath
+	}
 
-	// Get base store key
-	sandboxNameRoot := dkm.GetKeyRoot(sandboxName)
-	baseKey = sandboxNameRoot + rnisKey
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + rnisKey + ":mep:" + mepName + ":"
 
 	// Connect to Redis DB (RNIS_DB)
 	rc, err = redis.NewConnector(redisAddr, RNIS_DB)
@@ -321,53 +369,34 @@ func Init() (err error) {
 	}
 	log.Info("SBI Initialized")
 
-	//register using MEC011
-	if appEnablementSupport {
-		//delay startup on purpose to give time for appEnablement pod to come up (if all coming up at the same time)
-		time.Sleep(2 * time.Second)
+	// Create App Enablement REST clients
+	if appEnablementEnabled {
+		// Create App Info client
+		appInfoClientCfg := appInfoClient.NewConfiguration()
+		appInfoClientCfg.BasePath = appEnablementUrl + "/app_info/v1"
+		appEnablementAppInfoClient = appInfoClient.NewAPIClient(appInfoClientCfg)
+		if appEnablementAppInfoClient == nil {
+			return errors.New("Failed to create App Info REST API client")
+		}
 
-		retryAppEnablementTicker = time.NewTicker(time.Second)
-		go func() {
-			mecAppReadySent := false
-			registrationSent := false
-			for range retryAppEnablementTicker.C {
-				if serviceAppInstanceId == "" {
-					serviceAppInstanceId = getAppInstanceId(serviceAppName, serviceAppVersion)
-				}
-				if serviceAppInstanceId != "" {
-					//sending app is ready
-					if !mecAppReadySent {
-						err := appEnablementMecAppReady(serviceAppInstanceId)
-						if err != nil {
-							log.Error("Failure when sending the MecAppReady message, keep trying. Error: ", err)
-							continue
-						} else {
-							mecAppReadySent = true
-						}
-					}
-					if !registrationSent {
-						err := appEnablementRegistration(serviceAppInstanceId, serviceAppName, serviceAppVersion)
-						if err != nil {
-							log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
-							continue
-						} else {
-							registrationSent = true
-						}
-						/*						err = appEnablementAppSupportSubscribe(serviceAppInstanceId)
-												if err != nil {
-													log.Error("Failed to subscribe to graceful termination. Error: ", err)
-												}
-												sendAppTerminationWhenDone = true
-						*/
-					}
-					if mecAppReadySent && registrationSent {
-						retryAppEnablementTicker.Stop()
-					}
-				}
-			}
-		}()
+		// Create App Support client
+		appSupportClientCfg := appSupportClient.NewConfiguration()
+		appSupportClientCfg.BasePath = appEnablementUrl + "/mec_app_support/v1"
+		appEnablementAppSupportClient = appSupportClient.NewAPIClient(appSupportClientCfg)
+		if appEnablementAppSupportClient == nil {
+			return errors.New("Failed to create App Enablement App Support REST API client")
+		}
+
+		// Create App Info client
+		srvMgmtClientCfg := srvMgmtClient.NewConfiguration()
+		srvMgmtClientCfg.BasePath = appEnablementUrl + "/mec_service_mgmt/v1"
+		appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(srvMgmtClientCfg)
+		if appEnablementSrvMgmtClient == nil {
+			return errors.New("Failed to create App Enablement Service Management REST API client")
+		}
 	}
 
+	log.Info("RNIS successfully initialized")
 	return nil
 }
 
@@ -383,109 +412,114 @@ func reInit() {
 	_ = rc.ForEachJSONEntry(keyName, repopulateRrSubscriptionMap, nil)
 	_ = rc.ForEachJSONEntry(keyName, repopulateMrSubscriptionMap, nil)
 	_ = rc.ForEachJSONEntry(keyName, repopulateNrMrSubscriptionMap, nil)
-
 }
 
 // Run - Start RNIS
 func Run() (err error) {
+	// Start MEC Service registration ticker
+	if appEnablementEnabled {
+		startRegistrationTicker()
+	}
 	return sbi.Run()
 }
 
 // Stop - Stop RNIS
 func Stop() (err error) {
-	err = sbi.Stop()
-	if err != nil {
-		return err
-	}
-
-	if appEnablementSupport {
-		retryAppEnablementTicker.Stop()
-
+	// Stop MEC Service registration ticker
+	if appEnablementEnabled {
+		stopRegistrationTicker()
 		if sendAppTerminationWhenDone {
-			err = appEnablementMecAppTermination(serviceAppInstanceId)
+			err = sendTerminationConfirmation(serviceAppInstanceId)
 			if err != nil {
 				return err
 			}
 		}
 	}
-	return nil
+	return sbi.Stop()
 }
 
-func appEnablementMecAppReady(appInstanceId string) error {
-	appEnablementAppSupportClientCfg := appSupportClient.NewConfiguration()
-	appEnablementAppSupportClientCfg.BasePath = appEnablementClientUrl + "/mec_app_support/v1"
+func startRegistrationTicker() {
+	// Wait a few seconds to allow App Enablement Service to start.
+	// This is done to avoid the default 20 second TCP socket connect timeout
+	// if the App Enablement Service is not yet running.
+	log.Info("Waiting for App Enablement Service to start")
+	time.Sleep(5 * time.Second)
 
-	appEnablementAppSupportClient = appSupportClient.NewAPIClient(appEnablementAppSupportClientCfg)
-	if appEnablementAppSupportClient == nil {
-		log.Error("Failed to create App Enablement App Support REST API client: ", appEnablementAppSupportClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement AppSupport REST API client")
-		return err
-	}
-	var appReady appSupportClient.AppReadyConfirmation
-	//indication
-	indication := appSupportClient.READY_ReadyIndicationType
-	appReady.Indication = &indication
-	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
-	if err != nil {
-		log.Error("Failed to send a ready confirm acknowlegement: ", err)
-		return err
-	}
-	return nil
+	go func() {
+		mecAppReadySent := false
+		// registrationSent := false
+		for range registrationTicker.C {
+			// Get Application instance ID if not already available
+			if serviceAppInstanceId == "" {
+				var err error
+				serviceAppInstanceId, err = getAppInstanceId(serviceAppName, serviceAppVersion)
+				if err != nil || serviceAppInstanceId == "" {
+					continue
+				}
+			}
+
+			// Send App Ready message
+			if !mecAppReadySent {
+				err := sendReadyConfirmation(serviceAppInstanceId)
+				if err != nil {
+					log.Error("Failure when sending the MecAppReady message. Error: ", err)
+					continue
+				}
+				mecAppReadySent = true
+			}
+
+			// Register service instance
+			// if !registrationSent {
+			err := registerService(serviceAppInstanceId, serviceAppName, serviceAppVersion)
+			if err != nil {
+				log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
+				continue
+			}
+			// 	registrationSent = true
+			// }
+
+			// // Register for graceful termination
+			// if !subscriptionSent {
+			// 	err = subscribeAppTermination(serviceAppInstanceId)
+			// 	if err != nil {
+			// 		log.Error("Failed to subscribe to graceful termination. Error: ", err)
+			// 		continue
+			// 	}
+			// 	sendAppTerminationWhenDone = true
+			// 	subscriptionSent = true
+			// }
+
+			// Registration complete
+			log.Info("Successfully registered with App Enablement Service")
+			stopRegistrationTicker()
+			return
+		}
+	}()
 }
 
-func appEnablementMecAppTermination(appInstanceId string) error {
-
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
+func stopRegistrationTicker() {
+	if registrationTicker != nil {
+		log.Info("Stopping App Enablement registration ticker")
+		registrationTicker.Stop()
+		registrationTicker = nil
 	}
-	var appTermination appSupportClient.AppTerminationConfirmation
-	//operation action
-	operationAction := appSupportClient.TERMINATING_OperationActionType
-	appTermination.OperationAction = &operationAction
-	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
-	if err != nil {
-		log.Error("Failed to send a confirm termination acknowlegement: ", err)
-		return err
-	}
-	return nil
 }
 
-func getAppInstanceId(appName string, appVersion string) string {
-	//var client *appInfoClient.APIClient
-	appInfoClientCfg := appInfoClient.NewConfiguration()
-	appInfoClientCfg.BasePath = appEnablementClientUrl + "/app_info/v1"
-
-	client := appInfoClient.NewAPIClient(appInfoClientCfg)
-	if client == nil {
-		log.Error("Failed to create App Info REST API client: ", appInfoClientCfg.BasePath)
-		return ""
-	}
+func getAppInstanceId(appName string, appVersion string) (id string, err error) {
 	var appInfo appInfoClient.ApplicationInfo
 	appInfo.AppName = appName
 	appInfo.Version = appVersion
 	state := appInfoClient.INACTIVE_ApplicationState
 	appInfo.State = &state
-	appInfoResponse, _, err := client.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
+	appInfoResponse, _, err := appEnablementAppInfoClient.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
 	if err != nil {
-		log.Error("Failed to communicate with app enablement service: ", err)
-		return ""
+		log.Error("Failed to get App Instance ID with error: ", err)
+		return "", err
 	}
-	return appInfoResponse.AppInstanceId
+	return appInfoResponse.AppInstanceId, nil
 }
 
-func appEnablementRegistration(appInstanceId string, appName string, appVersion string) error {
-
-	appEnablementSrvMgmtClientCfg := srvMgmtClient.NewConfiguration()
-	appEnablementSrvMgmtClientCfg.BasePath = appEnablementClientUrl + "/mec_service_mgmt/v1"
-
-	appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(appEnablementSrvMgmtClientCfg)
-	if appEnablementSrvMgmtClient == nil {
-		log.Error("Failed to create App Enablement Srv Mgmt REST API client: ", appEnablementSrvMgmtClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement Srv Mgmt REST API client")
-		return err
-	}
+func registerService(appInstanceId string, appName string, appVersion string) error {
 	var srvInfo srvMgmtClient.ServiceInfoPost
 	//serName
 	srvInfo.SerName = appName
@@ -521,11 +555,11 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	srvInfo.SerCategory = &category
 
 	//scopeOfLocality
-	scopeOfLocality := srvMgmtClient.MEC_SYSTEM_LocalityType
-	srvInfo.ScopeOfLocality = &scopeOfLocality
+	localityType := srvMgmtClient.LocalityType(scopeOfLocality)
+	srvInfo.ScopeOfLocality = &localityType
 
 	//consumedLocalOnly
-	srvInfo.ConsumedLocalOnly = false
+	srvInfo.ConsumedLocalOnly = consumedLocalOnly
 
 	appServicesPostResponse, _, err := appEnablementSrvMgmtClient.AppServicesApi.AppServicesPOST(context.TODO(), srvInfo, appInstanceId)
 	if err != nil {
@@ -536,28 +570,43 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	return nil
 }
 
-/*
-func appEnablementAppSupportSubscribe(appInstanceId string) error {
-
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
-	}
-	var appTerminationNotificationSubscription appSupportClient.AppTerminationNotificationSubscription
-	//operation action
-	appTerminationNotificationSubscription.SubscriptionType = "AppTerminationNotificationSubscription"
-	appTerminationNotificationSubscription.AppInstanceId = appInstanceId
-	appTerminationNotificationSubscription.CallbackReference = hostUrl.String() + basePath
-
-	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), appTerminationNotificationSubscription, appInstanceId)
+func sendReadyConfirmation(appInstanceId string) error {
+	var appReady appSupportClient.AppReadyConfirmation
+	indication := appSupportClient.READY_ReadyIndicationType
+	appReady.Indication = &indication
+	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
 	if err != nil {
-		log.Error("Failed to register to App Support subscription: ", err)
+		log.Error("Failed to send a ready confirm acknowlegement: ", err)
 		return err
 	}
 	return nil
 }
-*/
+
+func sendTerminationConfirmation(appInstanceId string) error {
+	var appTermination appSupportClient.AppTerminationConfirmation
+	operationAction := appSupportClient.TERMINATING_OperationActionType
+	appTermination.OperationAction = &operationAction
+	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
+	if err != nil {
+		log.Error("Failed to send a confirm termination acknowlegement: ", err)
+		return err
+	}
+	return nil
+}
+
+// func subscribeAppTermination(appInstanceId string) error {
+// 	var subscription appSupportClient.AppTerminationNotificationSubscription
+// 	subscription.SubscriptionType = "AppTerminationNotificationSubscription"
+// 	subscription.AppInstanceId = appInstanceId
+// 	subscription.CallbackReference = hostUrl.String() + basePath
+// 	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), subscription, appInstanceId)
+// 	if err != nil {
+// 		log.Error("Failed to register to App Support subscription: ", err)
+// 		return err
+// 	}
+// 	return nil
+// }
+
 func updateUeData(obj sbi.UeDataSbi) {
 
 	var plmn Plmn

--- a/go-apps/meep-rnis/server/rnis.go
+++ b/go-apps/meep-rnis/server/rnis.go
@@ -440,12 +440,20 @@ func Stop() (err error) {
 }
 
 func startRegistrationTicker() {
+	// Make sure ticker is not running
+	if registrationTicker != nil {
+		log.Warn("Registration ticker already running")
+		return
+	}
+
 	// Wait a few seconds to allow App Enablement Service to start.
 	// This is done to avoid the default 20 second TCP socket connect timeout
 	// if the App Enablement Service is not yet running.
 	log.Info("Waiting for App Enablement Service to start")
 	time.Sleep(5 * time.Second)
 
+	// Start registration ticker
+	registrationTicker = time.NewTicker(5 * time.Second)
 	go func() {
 		mecAppReadySent := false
 		// registrationSent := false

--- a/go-apps/meep-virt-engine/server/chart-template.go
+++ b/go-apps/meep-virt-engine/server/chart-template.go
@@ -129,6 +129,7 @@ type SandboxTemplate struct {
 	AuthEnabled    bool
 	IsMepService   bool
 	MepName        string
+	Env            []string
 }
 
 // Deploy - Generate charts & deploy single process or entire scenario
@@ -247,6 +248,9 @@ func generateScenarioCharts(sandboxName string, procName string, model *mod.Mode
 		} else if mepService := getMepService(proc); mepService != "" {
 			log.Debug("Processing MEP Service chart for element[", proc.Name, "]")
 
+			// Get MEP Name
+			mepName := ctx.Parents[mod.PhyLoc]
+
 			// Create Sandbox template
 			var sandboxTemplate SandboxTemplate
 			sandboxTemplate.SandboxName = sandboxName
@@ -255,10 +259,16 @@ func generateScenarioCharts(sandboxName string, procName string, model *mod.Mode
 			sandboxTemplate.HttpsOnly = ve.httpsOnly
 			sandboxTemplate.AuthEnabled = ve.authEnabled
 			sandboxTemplate.IsMepService = true
-
-			// Get MEP Name
-			mepName := ctx.Parents[mod.PhyLoc]
 			sandboxTemplate.MepName = mepName
+
+			// Set environment variables in template
+			if proc.Environment != "" {
+				allVar := strings.Split(proc.Environment, ",")
+				for _, oneVar := range allVar {
+					nameValue := strings.Split(oneVar, "=")
+					sandboxTemplate.Env = append(sandboxTemplate.Env, strings.TrimSpace(nameValue[0])+": "+strings.TrimSpace(nameValue[1]))
+				}
+			}
 
 			// Create chart
 			chartName := proc.Name

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -331,12 +331,20 @@ func Stop() (err error) {
 }
 
 func startRegistrationTicker() {
+	// Make sure ticker is not running
+	if registrationTicker != nil {
+		log.Warn("Registration ticker already running")
+		return
+	}
+
 	// Wait a few seconds to allow App Enablement Service to start.
 	// This is done to avoid the default 20 second TCP socket connect timeout
 	// if the App Enablement Service is not yet running.
 	log.Info("Waiting for App Enablement Service to start")
 	time.Sleep(5 * time.Second)
 
+	// Start registration ticker
+	registrationTicker = time.NewTicker(5 * time.Second)
 	go func() {
 		mecAppReadySent := false
 		// registrationSent := false

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -45,10 +45,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const waisBasePath = "/wai/v2/"
-const waisKey = "wais:"
+const waisBasePath = "wai/v2/"
+const waisKey = "wais"
 const logModuleWAIS = "meep-wais"
 const serviceName = "WAI Service"
+const defaultMepName = "global"
+const defaultScopeOfLocality = "MEC_SYSTEM"
+const defaultConsumedLocalOnly = true
 
 const (
 	notifAssocSta    = "AssocStaNotification"
@@ -76,11 +79,15 @@ var staDataRateSubscriptionInfoMap = map[int]*StaDataRateSubscriptionInfo{}
 
 var subscriptionExpiryMap = map[int][]int{}
 
-var WAIS_DB = 5
+var WAIS_DB = 0
 
 var rc *redis.Connector
 var hostUrl *url.URL
 var sandboxName string
+var mepName string = defaultMepName
+var scopeOfLocality string = defaultScopeOfLocality
+var consumedLocalOnly bool = defaultConsumedLocalOnly
+var locality []string
 var basePath string
 var baseKey string
 var mutex sync.Mutex
@@ -125,25 +132,25 @@ type ApInfoResp struct {
 	ApInfoList []ApInfo
 }
 
-//MEC011 section begin
 const serviceAppName = "WAI"
 const serviceAppVersion = "2.1.1"
 
 var serviceAppInstanceId string
 
-var appEnablementClientUrl string = "http://meep-app-enablement"
-var appEnablementSupport bool = true
-var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
-var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementUrl string
+var appEnablementEnabled bool = false
 var sendAppTerminationWhenDone bool = false
-var retryAppEnablementTicker *time.Ticker
+var appEnablementAppSupportClient *appSupportClient.APIClient
+var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
+var appEnablementAppInfoClient *appInfoClient.APIClient
 
-//MEC011 section end
+var registrationTicker *time.Ticker
 
 func notImplemented(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusNotImplemented)
 }
+
 func Init() (err error) {
 
 	// Retrieve Sandbox name from environment variable
@@ -167,13 +174,56 @@ func Init() (err error) {
 			hostUrl = new(url.URL)
 		}
 	}
-	log.Info("resource URL: ", hostUrl)
+	log.Info("MEEP_HOST_URL: ", hostUrl)
+
+	// Get MEP name
+	mepNameEnv := strings.TrimSpace(os.Getenv("MEEP_MEP_NAME"))
+	if mepNameEnv != "" {
+		mepName = mepNameEnv
+	}
+	log.Info("MEEP_MEP_NAME: ", mepName)
+
+	// Get App Enablement URL
+	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
+	if appEnablementEnv != "" {
+		appEnablementUrl = "http://" + appEnablementEnv
+		appEnablementEnabled = true
+	}
+	log.Info("MEEP_APP_ENABLEMENT: ", appEnablementUrl)
+
+	// Get scope of locality
+	scopeOfLocalityEnv := strings.TrimSpace(os.Getenv("MEEP_SCOPE_OF_LOCALITY"))
+	if scopeOfLocalityEnv != "" {
+		scopeOfLocality = scopeOfLocalityEnv
+	}
+	log.Info("MEEP_SCOPE_OF_LOCALITY: ", scopeOfLocality)
+
+	// Get local consumption
+	consumedLocalOnlyEnv := strings.TrimSpace(os.Getenv("MEEP_CONSUMED_LOCAL_ONLY"))
+	if consumedLocalOnlyEnv != "" {
+		value, err := strconv.ParseBool(consumedLocalOnlyEnv)
+		if err == nil {
+			consumedLocalOnly = value
+		}
+	}
+	log.Info("MEEP_CONSUMED_LOCAL_ONLY: ", consumedLocalOnly)
+
+	// Get locality
+	localityEnv := strings.TrimSpace(os.Getenv("MEEP_LOCALITY"))
+	if localityEnv != "" {
+		locality = strings.Split(localityEnv, ":")
+	}
+	log.Info("MEEP_LOCALITY: ", locality)
 
 	// Set base path
-	basePath = "/" + sandboxName + waisBasePath
+	if mepName == defaultMepName {
+		basePath = "/" + sandboxName + "/" + waisBasePath
+	} else {
+		basePath = "/" + sandboxName + "/" + mepName + "/" + waisBasePath
+	}
 
-	// Get base store key
-	baseKey = dkm.GetKeyRoot(sandboxName) + waisKey
+	// Set base storage key
+	baseKey = dkm.GetKeyRoot(sandboxName) + waisKey + ":mep:" + mepName + ":"
 
 	// Connect to Redis DB
 	rc, err = redis.NewConnector(redisAddr, WAIS_DB)
@@ -213,54 +263,34 @@ func Init() (err error) {
 	}
 	log.Info("SBI Initialized")
 
-	//register using MEC011
-	if appEnablementSupport {
-		//delay startup on purpose to give time for appEnablement pod to come up (if all coming up at the same time)
-		time.Sleep(2 * time.Second)
+	// Create App Enablement REST clients
+	if appEnablementEnabled {
+		// Create App Info client
+		appInfoClientCfg := appInfoClient.NewConfiguration()
+		appInfoClientCfg.BasePath = appEnablementUrl + "/app_info/v1"
+		appEnablementAppInfoClient = appInfoClient.NewAPIClient(appInfoClientCfg)
+		if appEnablementAppInfoClient == nil {
+			return errors.New("Failed to create App Info REST API client")
+		}
 
-		retryAppEnablementTicker = time.NewTicker(time.Second)
-		go func() {
-			mecAppReadySent := false
-			registrationSent := false
-			for range retryAppEnablementTicker.C {
-				if serviceAppInstanceId == "" {
-					serviceAppInstanceId = getAppInstanceId(serviceAppName, serviceAppVersion)
-				}
-				if serviceAppInstanceId != "" {
-					//sending app is ready
-					if !mecAppReadySent {
-						err := appEnablementMecAppReady(serviceAppInstanceId)
-						if err != nil {
-							log.Error("Failure when sending the MecAppReady message, keep trying. Error: ", err)
-							continue
-						} else {
-							mecAppReadySent = true
-						}
-					}
-					if !registrationSent {
-						err := appEnablementRegistration(serviceAppInstanceId, serviceAppName, serviceAppVersion)
-						if err != nil {
-							log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
-							continue
-						} else {
-							registrationSent = true
-						}
-						/*
-							err = appEnablementAppSupportSubscribe(serviceAppInstanceId)
-							if err != nil {
-								log.Error("Failed to subscribe to graceful termination. Error: ", err)
-							}
-							sendAppTerminationWhenDone = true
-						*/
-					}
-					if mecAppReadySent && registrationSent {
-						retryAppEnablementTicker.Stop()
-					}
-				}
-			}
-		}()
+		// Create App Support client
+		appSupportClientCfg := appSupportClient.NewConfiguration()
+		appSupportClientCfg.BasePath = appEnablementUrl + "/mec_app_support/v1"
+		appEnablementAppSupportClient = appSupportClient.NewAPIClient(appSupportClientCfg)
+		if appEnablementAppSupportClient == nil {
+			return errors.New("Failed to create App Enablement App Support REST API client")
+		}
+
+		// Create App Info client
+		srvMgmtClientCfg := srvMgmtClient.NewConfiguration()
+		srvMgmtClientCfg.BasePath = appEnablementUrl + "/mec_service_mgmt/v1"
+		appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(srvMgmtClientCfg)
+		if appEnablementSrvMgmtClient == nil {
+			return errors.New("Failed to create App Enablement Service Management REST API client")
+		}
 	}
 
+	log.Info("WAIS successfully initialized")
 	return nil
 }
 
@@ -276,102 +306,111 @@ func reInit() {
 
 // Run - Start WAIS
 func Run() (err error) {
+	// Start MEC Service registration ticker
+	if appEnablementEnabled {
+		startRegistrationTicker()
+	}
 	return sbi.Run()
 }
 
 // Stop - Stop WAIS
 func Stop() (err error) {
-	err = sbi.Stop()
-	if err != nil {
-		return err
-	}
-	if appEnablementSupport {
-		retryAppEnablementTicker.Stop()
+	// Stop MEC Service registration ticker
+	if appEnablementEnabled {
+		stopRegistrationTicker()
 		if sendAppTerminationWhenDone {
-			err = appEnablementMecAppTermination(serviceAppInstanceId)
+			err = sendTerminationConfirmation(serviceAppInstanceId)
 			if err != nil {
 				return err
 			}
 		}
 	}
-	return nil
+
+	return sbi.Stop()
 }
 
-func appEnablementMecAppReady(appInstanceId string) error {
-	appEnablementAppSupportClientCfg := appSupportClient.NewConfiguration()
-	appEnablementAppSupportClientCfg.BasePath = appEnablementClientUrl + "/mec_app_support/v1"
+func startRegistrationTicker() {
+	// Wait a few seconds to allow App Enablement Service to start.
+	// This is done to avoid the default 20 second TCP socket connect timeout
+	// if the App Enablement Service is not yet running.
+	log.Info("Waiting for App Enablement Service to start")
+	time.Sleep(5 * time.Second)
 
-	appEnablementAppSupportClient = appSupportClient.NewAPIClient(appEnablementAppSupportClientCfg)
-	if appEnablementAppSupportClient == nil {
-		log.Error("Failed to create App Enablement App Support REST API client: ", appEnablementAppSupportClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement AppSupport REST API client")
-		return err
-	}
-	var appReady appSupportClient.AppReadyConfirmation
-	//indication
-	indication := appSupportClient.READY_ReadyIndicationType
-	appReady.Indication = &indication
-	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
-	if err != nil {
-		log.Error("Failed to send a ready confirm acknowlegement: ", err)
-		return err
-	}
-	return nil
+	go func() {
+		mecAppReadySent := false
+		// registrationSent := false
+		for range registrationTicker.C {
+			// Get Application instance ID if not already available
+			if serviceAppInstanceId == "" {
+				var err error
+				serviceAppInstanceId, err = getAppInstanceId(serviceAppName, serviceAppVersion)
+				if err != nil || serviceAppInstanceId == "" {
+					continue
+				}
+			}
+
+			// Send App Ready message
+			if !mecAppReadySent {
+				err := sendReadyConfirmation(serviceAppInstanceId)
+				if err != nil {
+					log.Error("Failure when sending the MecAppReady message. Error: ", err)
+					continue
+				}
+				mecAppReadySent = true
+			}
+
+			// Register service instance
+			// if !registrationSent {
+			err := registerService(serviceAppInstanceId, serviceAppName, serviceAppVersion)
+			if err != nil {
+				log.Error("Failed to register to appEnablement DB, keep trying. Error: ", err)
+				continue
+			}
+			// 	registrationSent = true
+			// }
+
+			// // Register for graceful termination
+			// if !subscriptionSent {
+			// 	err = subscribeAppTermination(serviceAppInstanceId)
+			// 	if err != nil {
+			// 		log.Error("Failed to subscribe to graceful termination. Error: ", err)
+			// 		continue
+			// 	}
+			// 	sendAppTerminationWhenDone = true
+			// 	subscriptionSent = true
+			// }
+
+			// Registration complete
+			log.Info("Successfully registered with App Enablement Service")
+			stopRegistrationTicker()
+			return
+		}
+	}()
 }
 
-func appEnablementMecAppTermination(appInstanceId string) error {
-
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
+func stopRegistrationTicker() {
+	if registrationTicker != nil {
+		log.Info("Stopping App Enablement registration ticker")
+		registrationTicker.Stop()
+		registrationTicker = nil
 	}
-	var appTermination appSupportClient.AppTerminationConfirmation
-	//operation action
-	operationAction := appSupportClient.TERMINATING_OperationActionType
-	appTermination.OperationAction = &operationAction
-	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
-	if err != nil {
-		log.Error("Failed to send a confirm termination acknowlegement: ", err)
-		return err
-	}
-	return nil
 }
 
-func getAppInstanceId(appName string, appVersion string) string {
-	//var client *appInfoClient.APIClient
-	appInfoClientCfg := appInfoClient.NewConfiguration()
-	appInfoClientCfg.BasePath = appEnablementClientUrl + "/app_info/v1"
-
-	client := appInfoClient.NewAPIClient(appInfoClientCfg)
-	if client == nil {
-		log.Error("Failed to create App Info REST API client: ", appInfoClientCfg.BasePath)
-		return ""
-	}
+func getAppInstanceId(appName string, appVersion string) (id string, err error) {
 	var appInfo appInfoClient.ApplicationInfo
 	appInfo.AppName = appName
 	appInfo.Version = appVersion
 	state := appInfoClient.INACTIVE_ApplicationState
 	appInfo.State = &state
-	appInfoResponse, _, err := client.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
+	appInfoResponse, _, err := appEnablementAppInfoClient.AppsApi.ApplicationsPOST(context.TODO(), appInfo)
 	if err != nil {
-		log.Error("Failed to communicate with app enablement service: ", err)
-		return ""
+		log.Error("Failed to get App Instance ID with error: ", err)
+		return "", err
 	}
-	return appInfoResponse.AppInstanceId
+	return appInfoResponse.AppInstanceId, nil
 }
 
-func appEnablementRegistration(appInstanceId string, appName string, appVersion string) error {
-
-	appEnablementSrvMgmtClientCfg := srvMgmtClient.NewConfiguration()
-	appEnablementSrvMgmtClientCfg.BasePath = appEnablementClientUrl + "/mec_service_mgmt/v1"
-
-	appEnablementSrvMgmtClient = srvMgmtClient.NewAPIClient(appEnablementSrvMgmtClientCfg)
-	if appEnablementSrvMgmtClient == nil {
-		log.Error("Failed to create App Enablement Srv Mgmt REST API client: ", appEnablementSrvMgmtClientCfg.BasePath)
-		err := errors.New("Failed to create App Enablement Srv Mgmt REST API client")
-		return err
-	}
+func registerService(appInstanceId string, appName string, appVersion string) error {
 	var srvInfo srvMgmtClient.ServiceInfoPost
 	//serName
 	srvInfo.SerName = appName
@@ -407,11 +446,11 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	srvInfo.SerCategory = &category
 
 	//scopeOfLocality
-	scopeOfLocality := srvMgmtClient.MEC_SYSTEM_LocalityType
-	srvInfo.ScopeOfLocality = &scopeOfLocality
+	localityType := srvMgmtClient.LocalityType(scopeOfLocality)
+	srvInfo.ScopeOfLocality = &localityType
 
 	//consumedLocalOnly
-	srvInfo.ConsumedLocalOnly = false
+	srvInfo.ConsumedLocalOnly = consumedLocalOnly
 
 	appServicesPostResponse, _, err := appEnablementSrvMgmtClient.AppServicesApi.AppServicesPOST(context.TODO(), srvInfo, appInstanceId)
 	if err != nil {
@@ -422,28 +461,43 @@ func appEnablementRegistration(appInstanceId string, appName string, appVersion 
 	return nil
 }
 
-/*
-func appEnablementAppSupportSubscribe(appInstanceId string) error {
-
-	if appEnablementAppSupportClient == nil {
-		log.Error("App Enablement App Support REST API client should already exist")
-		err := errors.New("App Enablement App Support REST API client should already exist")
-		return err
-	}
-	var appTerminationNotificationSubscription appSupportClient.AppTerminationNotificationSubscription
-	//operation action
-	appTerminationNotificationSubscription.SubscriptionType = "AppTerminationNotificationSubscription"
-	appTerminationNotificationSubscription.AppInstanceId = appInstanceId
-	appTerminationNotificationSubscription.CallbackReference = hostUrl.String() + basePath
-
-	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), appTerminationNotificationSubscription, appInstanceId)
+func sendReadyConfirmation(appInstanceId string) error {
+	var appReady appSupportClient.AppReadyConfirmation
+	indication := appSupportClient.READY_ReadyIndicationType
+	appReady.Indication = &indication
+	_, err := appEnablementAppSupportClient.AppConfirmReadyApi.ApplicationsConfirmReadyPOST(context.TODO(), appReady, appInstanceId)
 	if err != nil {
-		log.Error("Failed to register to App Support subscription: ", err)
+		log.Error("Failed to send a ready confirm acknowlegement: ", err)
 		return err
 	}
 	return nil
 }
-*/
+
+func sendTerminationConfirmation(appInstanceId string) error {
+	var appTermination appSupportClient.AppTerminationConfirmation
+	operationAction := appSupportClient.TERMINATING_OperationActionType
+	appTermination.OperationAction = &operationAction
+	_, err := appEnablementAppSupportClient.AppConfirmTerminationApi.ApplicationsConfirmTerminationPOST(context.TODO(), appTermination, appInstanceId)
+	if err != nil {
+		log.Error("Failed to send a confirm termination acknowlegement: ", err)
+		return err
+	}
+	return nil
+}
+
+// func subscribeAppTermination(appInstanceId string) error {
+// 	var subscription appSupportClient.AppTerminationNotificationSubscription
+// 	subscription.SubscriptionType = "AppTerminationNotificationSubscription"
+// 	subscription.AppInstanceId = appInstanceId
+// 	subscription.CallbackReference = hostUrl.String() + basePath
+// 	_, _, err := appEnablementAppSupportClient.AppSubscriptionsApi.ApplicationsSubscriptionsPOST(context.TODO(), subscription, appInstanceId)
+// 	if err != nil {
+// 		log.Error("Failed to register to App Support subscription: ", err)
+// 		return err
+// 	}
+// 	return nil
+// }
+
 func updateStaInfo(name string, ownMacId string, apMacId string, rssi *int32, sumUl *int32, sumDl *int32) {
 
 	// Get STA Info from DB, if any

--- a/go-apps/meep-wais/server/wais.go
+++ b/go-apps/meep-wais/server/wais.go
@@ -138,7 +138,7 @@ const serviceAppVersion = "2.1.1"
 var serviceAppInstanceId string
 
 var appEnablementUrl string
-var appEnablementEnabled bool = false
+var appEnablementEnabled bool
 var sendAppTerminationWhenDone bool = false
 var appEnablementAppSupportClient *appSupportClient.APIClient
 var appEnablementSrvMgmtClient *srvMgmtClient.APIClient
@@ -184,6 +184,7 @@ func Init() (err error) {
 	log.Info("MEEP_MEP_NAME: ", mepName)
 
 	// Get App Enablement URL
+	appEnablementEnabled = false
 	appEnablementEnv := strings.TrimSpace(os.Getenv("MEEP_APP_ENABLEMENT"))
 	if appEnablementEnv != "" {
 		appEnablementUrl = "http://" + appEnablementEnv

--- a/go-packages/meep-model/model.go
+++ b/go-packages/meep-model/model.go
@@ -942,16 +942,19 @@ func (m *Model) GetNodeChild(name string) (child interface{}) {
 }
 
 // GetNodeContext - Get a node context
-// 		Returned value is of type interface{}
-//    Good practice: returned node should be type asserted with val,ok := node.(someType) to prevent panic
-func (m *Model) GetNodeContext(name string) (ctx interface{}) {
+func (m *Model) GetNodeContext(name string) (ctx *NodeContext) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
 	ctx = nil
 	n := m.nodeMap.nameMap[name]
 	if n != nil {
-		ctx = n.context
+		nodeCtx := n.context
+		var ok bool
+		if ctx, ok = nodeCtx.(*NodeContext); !ok {
+			log.Error("Error casting node context for node: " + name)
+			return nil
+		}
 	}
 	return ctx
 }

--- a/go-packages/meep-model/model_test.go
+++ b/go-packages/meep-model/model_test.go
@@ -1007,8 +1007,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok := ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "", "", "", "") {
+	if !validateNodeContext(ctx, "demo1", "", "", "", "") {
 		t.Fatalf("Invalid Deployment context")
 	}
 	fmt.Println("Get Operator context")
@@ -1016,8 +1015,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok = ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "operator1", "", "", "") {
+	if !validateNodeContext(ctx, "demo1", "operator1", "", "", "") {
 		t.Fatalf("Invalid Operator context")
 	}
 	fmt.Println("Get Zone context")
@@ -1025,8 +1023,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok = ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "operator1", "zone1", "", "") {
+	if !validateNodeContext(ctx, "demo1", "operator1", "zone1", "", "") {
 		t.Fatalf("Invalid Operator context")
 	}
 	fmt.Println("Get Net Location context")
@@ -1034,8 +1031,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok = ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "operator1", "zone1", "zone1-poa1", "") {
+	if !validateNodeContext(ctx, "demo1", "operator1", "zone1", "zone1-poa1", "") {
 		t.Fatalf("Invalid Operator context")
 	}
 	fmt.Println("Get Phy Location context")
@@ -1043,8 +1039,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok = ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "operator1", "zone1", "zone1-poa1", "zone1-fog1") {
+	if !validateNodeContext(ctx, "demo1", "operator1", "zone1", "zone1-poa1", "zone1-fog1") {
 		t.Fatalf("Invalid Operator context")
 	}
 	fmt.Println("Get App context")
@@ -1052,8 +1047,7 @@ func TestGetters(t *testing.T) {
 	if ctx == nil {
 		t.Fatalf("Node context should exist")
 	}
-	nodeCtx, ok = ctx.(*NodeContext)
-	if !ok || !validateNodeContext(nodeCtx, "demo1", "operator1", "zone1", "zone1-poa1", "ue1") {
+	if !validateNodeContext(ctx, "demo1", "operator1", "zone1", "zone1-poa1", "ue1") {
 		t.Fatalf("Invalid Operator context")
 	}
 

--- a/go-packages/meep-net-char-mgr/algo-segment.go
+++ b/go-packages/meep-net-char-mgr/algo-segment.go
@@ -193,25 +193,20 @@ func (algo *SegmentAlgorithm) ProcessScenario(model *mod.Model, pduSessions map[
 			err := errors.New("Error getting context for process: " + name)
 			return err
 		}
-		nodeCtx, ok := ctx.(*mod.NodeContext)
-		if !ok {
-			err := errors.New("Error casting context for process: " + name)
-			return err
-		}
 
 		// Create & populate new element
 		element := new(SegAlgoNetElem)
 		element.Name = proc.Name
-		element.PhyLocName = nodeCtx.Parents[mod.PhyLoc]
-		element.DomainName = nodeCtx.Parents[mod.Domain]
+		element.PhyLocName = ctx.Parents[mod.PhyLoc]
+		element.DomainName = ctx.Parents[mod.Domain]
 
 		// Type-specific values
 		element.Type = model.GetNodeType(element.PhyLocName)
 		if element.Type == "UE" || element.Type == "FOG" {
-			element.PoaName = nodeCtx.Parents[mod.NetLoc]
+			element.PoaName = ctx.Parents[mod.NetLoc]
 		}
 		if element.Type != "DC" {
-			element.ZoneName = nodeCtx.Parents[mod.Zone]
+			element.ZoneName = ctx.Parents[mod.Zone]
 		}
 
 		deployment := model.GetNodeParent(element.DomainName).(*dataModel.Deployment)


### PR DESCRIPTION
**CHANGES:**
- MEC Service helm charts:
  - Added support for multiple instances (i.e. deployment as a MEP scenario pod)
  - Removed hardcoded service names & ingress rules
- App enablement:
  - Removed hardcoded MEP name
  - Modified basepath & keys to support data locality
- Location Service:
  - SBI: support for locality
- MEC Services:
  - Multiple instance support & data isolation
  - New environment variables for app enablement:
    - MEEP_APP_ENABLEMENT: App enablement service name
    - MEEP_SCOPE_OF_LOCALITY: Scope of locality (MEC_SYSTEM or MEC_HOST)
    - MEEP_CONSUMED_LOCAL_ONLY: Can be consumed only local to MEP?
    - MEEP_LOCALITY: Service locality
- Virt Engine:
  - Support for MEP Service deployments (scenario pods deployed using sandbox charts)
  - Patch to retrieve MEP service name from Process image name
  - Sandbox template updates to configure MEP services
- Webhook:
  - Patch to add env var to scenario pods
    - MEEP_POD_NAME
    - MEEP_SANDBOX_NAME
    - MEEP_SCENARIO_NAME
- Model package:
  - Updated context return value + adapted code accordingly

**TESTING:**
- UT, system & cypress tests pass