### PR TITLE
PaaS - MEP Service Permissions

### DIFF
--- a/config/permissions-open.yaml
+++ b/config/permissions-open.yaml
@@ -127,6 +127,7 @@ default:
 # #
 # #  FORMAT:
 # #  - name: 'svc-name'                   # service name
+# #    api: 'api-name'                    # API-specific identifier (when service has multiple APIs)
 # #    path: '/svc/base/path'             # service base path
 # #    sbox: true|false                   # sandbox deployment
 # #    default:                           # default service permissions
@@ -144,6 +145,34 @@ default:
 # #          user: 'allow|block'
 # #------------------------------------------------------------------------------
 # services:
+#   #------------------------------
+#   #  MEC Application Support (Sbox)
+#   #------------------------------
+#   - name: 'meep-app-enablement'
+#     api: 'mec_app_support'
+#     path: '/mec_app_support/v1'
+#     sbox: true
+#     default:
+#       mode: 'allow'
+#     endpoints:
+#       - name: 'Index'
+#         path: '/'
+#         method: 'GET'
+#         mode: 'block'
+#   #------------------------------
+#   #  MEC Service Management (Sbox)
+#   #------------------------------
+#   - name: 'meep-app-enablement'
+#     api: 'mec_service_mgmt'
+#     path: '/mec_service_mgmt/v1'
+#     sbox: true
+#     default:
+#       mode: 'allow'
+#     endpoints:
+#       - name: 'Index'
+#         path: '/'
+#         method: 'GET'
+#         mode: 'block'
 #   #------------------------------
 #   #  GIS Engine (Sbox)
 #   #------------------------------
@@ -221,45 +250,6 @@ default:
 #   #------------------------------
 #   - name: 'meep-loc-serv'
 #     path: '/location/v2'
-#     sbox: true
-#     default:
-#       mode: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#   #------------------------------
-#   #  MEC Application Support (Sbox)
-#   #------------------------------
-#   - name: 'meep-app-enablement-app-supp'
-#     path: '/mec_app_support/v1'
-#     sbox: true
-#     default:
-#       mode: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#   #------------------------------
-#   #  MEC Service Management (Sbox)
-#   #------------------------------
-#   - name: 'meep-app-enablement-srv-mgmt'
-#     path: '/mec_service_mgmt/v1'
-#     sbox: true
-#     default:
-#       mode: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#   #------------------------------
-#   #  Application Information (Sbox)
-#   #------------------------------
-#   - name: 'meep-app-enablement-app-info'
-#     path: '/app_info/v1'
 #     sbox: true
 #     default:
 #       mode: 'allow'
@@ -531,6 +521,41 @@ default:
 #         roles:
 #           admin: 'allow'
 #           user: 'allow'
+#       - name: 'GetActiveScenarioDomain'
+#         path: '/active/domains'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'GetActiveScenarioNetworkLocation'
+#         path: '/active/networkLocations'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'GetActiveScenarioPhysicalLocation'
+#         path: '/active/physicalLocations'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'GetActiveScenarioProcess'
+#         path: '/active/processes'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'GetActiveScenarioZone'
+#         path: '/active/zones'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
 #       - name: 'TerminateScenario'
 #         path: '/active'
 #         method: 'DELETE'
@@ -538,6 +563,62 @@ default:
 #         roles:
 #           admin: 'allow'
 #           user: 'allow'
+#       - name: 'ApplicationsAppInstanceIdDELETE'
+#         path: '/applications/{appInstanceId}'
+#         method: 'DELETE'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'ApplicationsAppInstanceIdGET'
+#         path: '/applications/{appInstanceId}'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'ApplicationsAppInstanceIdPUT'
+#         path: '/applications/{appInstanceId}'
+#         method: 'PUT'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'block'
+#       - name: 'ApplicationsGET'
+#         path: '/applications'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'ApplicationsPOST'
+#         path: '/applications'
+#         method: 'POST'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'allow'
+#       - name: 'CreatePduSession'
+#         path: '/connectivity/pdu-session/{ueName}/{pduSessionId}'
+#         method: 'POST'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'block'
+#       - name: 'GetPduSessionList'
+#         path: '/connectivity/pdu-session'
+#         method: 'GET'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'block'
+#       - name: 'TerminatePduSession'
+#         path: '/connectivity/pdu-session/{ueName}/{pduSessionId}'
+#         method: 'DELETE'
+#         mode: 'verify'
+#         roles:
+#           admin: 'allow'
+#           user: 'block'
 #       - name: 'CreateReplayFile'
 #         path: '/replay/{name}'
 #         method: 'POST'

--- a/config/permissions-secure.yaml
+++ b/config/permissions-secure.yaml
@@ -127,6 +127,7 @@ fileservers:
 # #
 # #  FORMAT:
 # #  - name: 'svc-name'                   # service name
+# #    api: 'api-name'                    # API-specific identifier (when service has multiple APIs)
 # #    path: '/svc/base/path'             # service base path
 # #    sbox: true|false                   # sandbox deployment
 # #    default:                           # default service permissions
@@ -145,6 +146,30 @@ fileservers:
 # #------------------------------------------------------------------------------
 services:
   #------------------------------
+  #  MEC Application Support (Sbox)
+  #------------------------------
+  - name: 'meep-app-enablement'
+    api: 'mec_app_support'
+    path: '/mec_app_support/v1'
+    sbox: true
+    default:
+      mode: 'verify'
+      roles:
+       admin: 'allow'
+       user: 'allow'
+  #------------------------------
+  #  MEC Service Management (Sbox)
+  #------------------------------
+  - name: 'meep-app-enablement'
+    api: 'mec_service_mgmt'
+    path: '/mec_service_mgmt/v1'
+    sbox: true
+    default:
+      mode: 'verify'
+      roles:
+        admin: 'allow'
+        user: 'allow'
+  #------------------------------
   #  GIS Engine (Sbox)
   #------------------------------
   - name: 'meep-gis-engine'
@@ -155,56 +180,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'GetAutomationState'
-#         path: '/automation'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'GetAutomationStateByName'
-#         path: '/automation/{type}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'SetAutomationStateByName'
-#         path: '/automation/{type}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'DeleteGeoDataByName'
-#         path: '/geodata/{assetName}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetAssetData'
-#         path: '/geodata'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'GetGeoDataByName'
-#         path: '/geodata/{assetName}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'UpdateGeoDataByName'
-#         path: '/geodata/{assetName}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
   #------------------------------
   #  Location Service (Sbox)
   #------------------------------
@@ -216,43 +191,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-  #------------------------------
-  #  MEC Application Support (Sbox)
-  #------------------------------
-  - name: 'meep-app-enablement-app-supp'
-    path: '/mec_app_support/v1'
-    sbox: true
-    default:
-      mode: 'verify'
-      roles:
-       admin: 'allow'
-       user: 'allow'
-#    endpoints:
-#      - name: 'Index'
-#        path: '/'
-#        method: 'GET'
-#        mode: 'block'
-  #------------------------------
-  #  MEC Service Management (Sbox)
-  #------------------------------
-  - name: 'meep-app-enablement-srv-mgmt'
-    path: '/mec_service_mgmt/v1'
-    sbox: true
-    default:
-      mode: 'verify'
-      roles:
-        admin: 'allow'
-        user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
   #------------------------------
   #  Metrics Engine (Sbox)
   #------------------------------
@@ -264,84 +202,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'PostEventQuery'
-#         path: '/metrics/query/event'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'PostHttpQuery'
-#         path: '/metrics/query/http'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'PostNetworkQuery'
-#         path: '/metrics/query/network'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'CreateEventSubscription'
-#         path: '/metrics/subscriptions/event'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'CreateNetworkSubscription'
-#         path: '/metrics/subscriptions/network'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteEventSubscriptionById'
-#         path: '/metrics/subscriptions/event/{subscriptionId}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteNetworkSubscriptionById'
-#         path: '/metrics/subscriptions/network/{subscriptionId}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetEventSubscription'
-#         path: '/metrics/subscriptions/event'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetEventSubscriptionById'
-#         path: '/metrics/subscriptions/event/{subscriptionId}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetNetworkSubscription'
-#         path: '/metrics/subscriptions/network'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetNetworkSubscriptionById'
-#         path: '/metrics/subscriptions/network/{subscriptionId}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
   #------------------------------
   #  Mobility Group Manager (Sbox)
   #------------------------------
@@ -353,11 +213,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
   #------------------------------
   #  Monitoring Engine
   #------------------------------
@@ -369,18 +224,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#       - name: 'GetStates'
-#         path: '/states'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
   #------------------------------
   #  Platform Controller
   #------------------------------
@@ -392,95 +235,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#       - name: 'CreateSandbox'
-#         path: '/sandboxes'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'CreateSandboxWithName'
-#         path: '/sandboxes/{name}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteSandbox'
-#         path: '/sandboxes/{name}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteSandboxList'
-#         path: '/sandboxes'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetSandbox'
-#         path: '/sandboxes/{name}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'GetSandboxList'
-#         path: '/sandboxes'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'CreateScenario'
-#         path: '/scenarios/{name}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteScenario'
-#         path: '/scenarios/{name}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteScenarioList'
-#         path: '/scenarios'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetScenario'
-#         path: '/scenarios/{name}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'GetScenarioList'
-#         path: '/scenarios'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'SetScenario'
-#         path: '/scenarios/{name}'
-#         method: 'PUT'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
   #------------------------------
   #  RNI Service (Sbox)
   #------------------------------
@@ -492,11 +246,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
   #------------------------------
   #  Sandbox Controller (Sbox)
   #------------------------------
@@ -508,113 +257,6 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-#       - name: 'ActivateScenario'
-#         path: '/active/{name}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'GetActiveNodeServiceMaps'
-#         path: '/active/serviceMaps'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetActiveScenario'
-#         path: '/active'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'TerminateScenario'
-#         path: '/active'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'allow'
-#       - name: 'CreateReplayFile'
-#         path: '/replay/{name}'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'CreateReplayFileFromScenarioExec'
-#         path: '/replay/{name}/generate'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteReplayFile'
-#         path: '/replay/{name}'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'DeleteReplayFileList'
-#         path: '/replay'
-#         method: 'DELETE'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetReplayFile'
-#         path: '/replay/{name}'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetReplayFileList'
-#         path: '/replay'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'GetReplayStatus'
-#         path: '/replaystatus'
-#         method: 'GET'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'LoopReplay'
-#         path: '/replay/{name}/loop'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'PlayReplayFile'
-#         path: '/replay/{name}/play'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'StopReplayFile'
-#         path: '/replay/{name}/stop'
-#         method: 'POST'
-#         mode: 'verify'
-#         roles:
-#           admin: 'allow'
-#           user: 'block'
-#       - name: 'SendEvent'
-#         path: '/events/{type}'
-#         method: 'POST'
-#         mode: 'allow'
   #------------------------------
   #  WAI Service (Sbox)
   #------------------------------
@@ -626,8 +268,3 @@ services:
       roles:
         admin: 'allow'
         user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'

--- a/config/permissions-secure.yaml
+++ b/config/permissions-secure.yaml
@@ -254,22 +254,6 @@ services:
 #         method: 'GET'
 #         mode: 'block'
   #------------------------------
-  #  App Information (Sbox)
-  #------------------------------
-  - name: 'meep-app-enablement-app-info'
-    path: '/app_info/v1'
-    sbox: true
-    default:
-      mode: 'verify'
-      roles:
-        admin: 'allow'
-        user: 'allow'
-#     endpoints:
-#       - name: 'Index'
-#         path: '/'
-#         method: 'GET'
-#         mode: 'block'
-  #------------------------------
   #  Metrics Engine (Sbox)
   #------------------------------
   - name: 'meep-metrics-engine'


### PR DESCRIPTION
**CHANGES:**
- Permissions Configuration:
  - Permissions endpoint updates to match latest code base
  - New 'api' config point to support services with multiple APIs
  - File cleanup
- Auth Service:
  - Permissions verification for services with multiple APIs
  - Permissions verification for MEP services
    - NOTE: Currently supports one permissions config point for all Sandbox/MEP deployments of a single service (i.e. no sandbox or mep-specific permissions)

**TESTING:**
- Manual verification of permissions rules