### PR TITLE
App Enablement permissions fix

### DIFF
--- a/go-apps/meep-auth-svc/server/auth-svc.go
+++ b/go-apps/meep-auth-svc/server/auth-svc.go
@@ -730,6 +730,17 @@ func asAuthenticate(w http.ResponseWriter, r *http.Request) {
 		if svcName != "" {
 			if svcPermissions, found := authSvc.cache.Services[svcName]; found {
 				permission = svcPermissions[routeName]
+			} else {
+				// Possibly a multi-API service.
+				// Search for prefix key matches in this case.
+				for key, permissions := range authSvc.cache.Services {
+					if strings.HasPrefix(key, svcName) {
+						permission = permissions[routeName]
+						if permission != nil {
+							break
+						}
+					}
+				}
 			}
 		}
 		// Check file servers if not already found


### PR DESCRIPTION
**CHANGES:**
- Auth Service:
  - When service name is passed but does not match any cached entries, a prefix match is used instead.