### PR TITLE
app-enablement testing fixes

### DIFF
--- a/go-apps/meep-ams/api/swagger.yaml
+++ b/go-apps/meep-ams/api/swagger.yaml
@@ -245,7 +245,7 @@ paths:
           $ref: '#/components/responses/406'          
         '429':
           $ref: '#/components/responses/429'  
-  /subscriptions/:   
+  /subscriptions/:
     get:
       tags:
       - 'amsi'

--- a/go-apps/meep-app-enablement/api/service-mgmt/swagger.yaml
+++ b/go-apps/meep-app-enablement/api/service-mgmt/swagger.yaml
@@ -702,7 +702,7 @@ components:
           version: '2.0'
           endpoint:
             uris:
-              - 'https://my.callback.com/sandboxname/mep1/rni/v2/'
+              - 'https://my.callback.com/sandboxname/rni/v2/'
         serializer: 'JSON'
         scopeOfLocality: 'MEC_SYSTEM'
         isLocal: true
@@ -1031,12 +1031,14 @@ components:
             $ref: '#/components/schemas/SerAvailabilityNotificationSubscription'
           example:
             subscriptionType: 'SerAvailabilityNotificationSubscription'
-            serNames: 
-              - 'myRnis'
-            states:
-              - 'ACTIVE'
-              - 'INACTIVE'
-            isLocal: true
+            callbackReference: "http://my.callback.com/mec_service_mgmt_ser_availabilities/some-id"
+            filterCriteria:
+              serNames: 
+                - 'myRnis'
+              states:
+                - 'ACTIVE'
+                - 'INACTIVE'
+              isLocal: true
       description: >-
         Entity body in the request contains a subscription to the MEC
         application termination notifications that is to be created.
@@ -1056,7 +1058,6 @@ components:
           schema:
             $ref: '#/components/schemas/ServiceInfoPost'
           example:
-            serInstanceId: 'rnisInstance1'
             serName: 'myRnis'
             serCategory:
               href: 'catItem1'
@@ -1074,7 +1075,7 @@ components:
               version: '2.0'
               endpoint:
                 uris:
-                  - 'https://my.callback.com/sandboxname/mep1/rni/v2/'
+                  - 'https://my.callback.com/sandboxname/rni/v2/'
             serializer: 'JSON'
             scopeOfLocality: 'MEC_SYSTEM'
             isLocal: true
@@ -1181,7 +1182,7 @@ components:
           version: '2.0'
           endpoint:
             uris:
-              - 'https://my.callback.com/sandboxname/mep1/rni/v2/'
+              - 'https://my.callback.com/sandboxname/rni/v2/'
         serializer: 'JSON'
         scopeOfLocality: 'MEC_SYSTEM'
         isLocal: true

--- a/go-apps/meep-app-enablement/api/service-mgmt/swagger.yaml
+++ b/go-apps/meep-app-enablement/api/service-mgmt/swagger.yaml
@@ -705,7 +705,6 @@ components:
               - 'https://my.callback.com/sandboxname/rni/v2/'
         serializer: 'JSON'
         scopeOfLocality: 'MEC_SYSTEM'
-        isLocal: true
     Subscription:
       description: A link to the related subscription
       type: object
@@ -1078,7 +1077,6 @@ components:
                   - 'https://my.callback.com/sandboxname/rni/v2/'
             serializer: 'JSON'
             scopeOfLocality: 'MEC_SYSTEM'
-            isLocal: true
       description: >-
         New ServiceInfo with updated "state" is included as entity body of the
         request
@@ -1185,6 +1183,5 @@ components:
               - 'https://my.callback.com/sandboxname/rni/v2/'
         serializer: 'JSON'
         scopeOfLocality: 'MEC_SYSTEM'
-        isLocal: true
 
 

--- a/go-apps/meep-app-enablement/server/service-mgmt/model_service_info.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/model_service_info.go
@@ -41,7 +41,9 @@ type ServiceInfo struct {
 
 	ScopeOfLocality *LocalityType `json:"scopeOfLocality,omitempty"`
 	// Indicate whether the service can only be consumed by the MEC applications located in the same locality (as defined by scopeOfLocality) as this  service instance.
-	ConsumedLocalOnly bool `json:"consumedLocalOnly,omitempty"`
+	// manually removed the omitempty
+	ConsumedLocalOnly bool `json:"consumedLocalOnly"`
 	// Indicate whether the service is located in the same locality (as defined by scopeOfLocality) as the consuming MEC application.
-	IsLocal bool `json:"isLocal,omitempty"`
+	// manually removed the omitempty
+	IsLocal bool `json:"isLocal"`
 }

--- a/go-apps/meep-app-enablement/server/service-mgmt/model_service_info_post.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/model_service_info_post.go
@@ -43,7 +43,7 @@ type ServiceInfoPost struct {
 
 	ScopeOfLocality *LocalityType `json:"scopeOfLocality,omitempty"`
 	// Indicate whether the service can only be consumed by the MEC applications located in the same locality (as defined by scopeOfLocality) as this  service instance.
-	ConsumedLocalOnly bool `json:"consumedLocalOnly,omitempty"`
+	ConsumedLocalOnly bool `json:"consumedLocalOnly"`
 	// Indicate whether the service is located in the same locality (as defined by scopeOfLocality) as the consuming MEC application.
-	IsLocal bool `json:"isLocal,omitempty"`
+	IsLocal bool `json:"isLocal"`
 }

--- a/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
+++ b/go-apps/meep-app-enablement/server/service-mgmt/service-mgmt.go
@@ -244,6 +244,13 @@ func sInfoPostDefaults(sInfoPost *ServiceInfoPost) {
 	sInfoPost.ConsumedLocalOnly = true
 }
 
+func sInfoDefaults(sInfo *ServiceInfo) {
+	locality := MEC_HOST
+	sInfo.ScopeOfLocality = &locality
+	sInfo.IsLocal = true
+	sInfo.ConsumedLocalOnly = true
+}
+
 func appServicesPOST(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	log.Info("appServicesPOST")
@@ -464,6 +471,7 @@ func appServicesByIdPUT(w http.ResponseWriter, r *http.Request) {
 
 	// Retrieve service info from request body
 	var sInfo ServiceInfo
+	sInfoDefaults(&sInfo)
 	decoder := json.NewDecoder(r.Body)
 	err = decoder.Decode(&sInfo)
 	if err != nil {
@@ -477,6 +485,7 @@ func appServicesByIdPUT(w http.ResponseWriter, r *http.Request) {
 	*sInfo.State = *sInfoPrev.State
 	//isLocal appears only in query responses and service avail. subs and notif, so not here, make sure both have same value so they are ignored
 	sInfo.IsLocal = sInfoPrev.IsLocal
+
 	sInfoJson := convertServiceInfoToJson(&sInfo)
 	if sInfoJson != sInfoPrevJson {
 		errStr := "Only the ServiceInfo state property may be changed"
@@ -845,6 +854,8 @@ func createSInfoFromSInfoPost(sInfoPost *ServiceInfoPost) *ServiceInfo {
 	sInfo.Serializer = sInfoPost.Serializer
 	sInfo.ScopeOfLocality = sInfoPost.ScopeOfLocality
 	sInfo.ConsumedLocalOnly = sInfoPost.ConsumedLocalOnly
+	// although IsLocal is reevaluated when a query is replied to, value stored in sInfo as is for now
+	sInfo.IsLocal = sInfoPost.IsLocal
 	return &sInfo
 }
 

--- a/go-apps/meep-sandbox-ctrl/api/swagger.yaml
+++ b/go-apps/meep-sandbox-ctrl/api/swagger.yaml
@@ -2338,8 +2338,8 @@ definitions:
         description: "Application Version"
     description: "MEC Application instance information"
     example:
-      appInstanceId: "00afec52-f0b6-464e-a660-33568c0975b9"
-      appName: "MyAppName"
+      id: "00afec52-f0b6-464e-a660-33568c0975b9"
+      name: "MyAppName"
       type: "USER"
       state: "INITIALIZED"
       mepName: "mep1"

--- a/go-packages/meep-data-model/api/swagger.yaml
+++ b/go-packages/meep-data-model/api/swagger.yaml
@@ -38,8 +38,8 @@ definitions:
         description: Application Version
         type: string
     example:
-      appInstanceId: '00afec52-f0b6-464e-a660-33568c0975b9'
-      appName: 'MyAppName'
+      id: '00afec52-f0b6-464e-a660-33568c0975b9'
+      name: 'MyAppName'
       type: 'USER'
       state: 'INITIALIZED'
       mepName: 'mep1'

--- a/go-packages/meep-sandbox-ctrl-client/api/swagger.yaml
+++ b/go-packages/meep-sandbox-ctrl-client/api/swagger.yaml
@@ -2338,8 +2338,8 @@ definitions:
         description: "Application Version"
     description: "MEC Application instance information"
     example:
-      appInstanceId: "00afec52-f0b6-464e-a660-33568c0975b9"
-      appName: "MyAppName"
+      id: "00afec52-f0b6-464e-a660-33568c0975b9"
+      name: "MyAppName"
       type: "USER"
       state: "INITIALIZED"
       mepName: "mep1"

--- a/go-packages/meep-service-mgmt-client/api/swagger.yaml
+++ b/go-packages/meep-service-mgmt-client/api/swagger.yaml
@@ -1197,10 +1197,9 @@ components:
           version: "2.0"
           endpoint:
             uris:
-            - https://my.callback.com/sandboxname/mep1/rni/v2/
+            - https://my.callback.com/sandboxname/rni/v2/
         serializer: JSON
         scopeOfLocality: MEC_SYSTEM
-        isLocal: true
     Subscription:
       required:
       - subscription
@@ -1674,10 +1673,9 @@ components:
           version: "2.0"
           endpoint:
             uris:
-            - https://my.callback.com/sandboxname/mep1/rni/v2/
+            - https://my.callback.com/sandboxname/rni/v2/
         serializer: JSON
         scopeOfLocality: MEC_SYSTEM
-        isLocal: true
   requestBodies:
     ApplicationsSubscriptions:
       description: Entity body in the request contains a subscription to the MEC application
@@ -1688,12 +1686,14 @@ components:
             $ref: '#/components/schemas/SerAvailabilityNotificationSubscription'
           example:
             subscriptionType: SerAvailabilityNotificationSubscription
-            serNames:
-            - myRnis
-            states:
-            - ACTIVE
-            - INACTIVE
-            isLocal: true
+            callbackReference: http://my.callback.com/mec_service_mgmt_ser_availabilities/some-id
+            filterCriteria:
+              serNames:
+              - myRnis
+              states:
+              - ACTIVE
+              - INACTIVE
+              isLocal: true
       required: true
     Services:
       description: New ServiceInfo with updated "state" is included as entity body
@@ -1711,7 +1711,6 @@ components:
           schema:
             $ref: '#/components/schemas/ServiceInfoPost'
           example:
-            serInstanceId: rnisInstance1
             serName: myRnis
             serCategory:
               href: catItem1
@@ -1729,10 +1728,9 @@ components:
               version: "2.0"
               endpoint:
                 uris:
-                - https://my.callback.com/sandboxname/mep1/rni/v2/
+                - https://my.callback.com/sandboxname/rni/v2/
             serializer: JSON
             scopeOfLocality: MEC_SYSTEM
-            isLocal: true
       required: true
     ServicesServiceId:
       description: New ServiceInfo with updated "state" is included as entity body

--- a/go-packages/meep-service-mgmt-client/model_service_info.go
+++ b/go-packages/meep-service-mgmt-client/model_service_info.go
@@ -36,7 +36,9 @@ type ServiceInfo struct {
 	Serializer      *SerializerType `json:"serializer"`
 	ScopeOfLocality *LocalityType   `json:"scopeOfLocality,omitempty"`
 	// Indicate whether the service can only be consumed by the MEC applications located in the same locality (as defined by scopeOfLocality) as this  service instance.
-	ConsumedLocalOnly bool `json:"consumedLocalOnly,omitempty"`
+        // manually removed the omitempty
+	ConsumedLocalOnly bool `json:"consumedLocalOnly"`
 	// Indicate whether the service is located in the same locality (as defined by scopeOfLocality) as the consuming MEC application.
-	IsLocal bool `json:"isLocal,omitempty"`
+        // manually removed the omitempty
+	IsLocal bool `json:"isLocal"`
 }

--- a/go-packages/meep-service-mgmt-client/model_service_info_post.go
+++ b/go-packages/meep-service-mgmt-client/model_service_info_post.go
@@ -38,7 +38,9 @@ type ServiceInfoPost struct {
 	Serializer      *SerializerType `json:"serializer"`
 	ScopeOfLocality *LocalityType   `json:"scopeOfLocality,omitempty"`
 	// Indicate whether the service can only be consumed by the MEC applications located in the same locality (as defined by scopeOfLocality) as this  service instance.
-	ConsumedLocalOnly bool `json:"consumedLocalOnly,omitempty"`
+	// manually removed the omitempty
+	ConsumedLocalOnly bool `json:"consumedLocalOnly"`
 	// Indicate whether the service is located in the same locality (as defined by scopeOfLocality) as the consuming MEC application.
-	IsLocal bool `json:"isLocal,omitempty"`
+        // manually removed the omitempty
+	IsLocal bool `json:"isLocal"`
 }


### PR DESCRIPTION
- removal of omitempty for serviceInfo attributes: isLocal and consumedLocalOnly
- default value support for scopeOfLocalitty, isLocal and consumedLocalOnly in serviceInfo object
- update to callbackReference to remove the duplication of mep1 in path
- update to example in service-mgmt service availability subscription
- validation of mandatory categoryRef attributes
- example in sandboxCtrl ApplicationInfo updated
