### PR TITLE
Demo3 Bug Fix

### DIFF
--- a/go-apps/meep-ams/server/ams.go
+++ b/go-apps/meep-ams/server/ams.go
@@ -1770,6 +1770,9 @@ func refreshTrackedDevCtxOwner(appName string) {
 		} else {
 			// Perform context transfer only if current App is no longer a valid target
 			ctxTransferRequired := true
+			if trackedDev[FieldCtxTransferState] == strconv.Itoa(int(ContextTransferState_USER_CONTEXT_TRANSFER_COMPLETED)) {
+				ctxTransferRequired = false
+			}
 			for _, targetAppId := range targetAppIds {
 				if targetAppId == currentAppId {
 					ctxTransferRequired = false


### PR DESCRIPTION
This PR makes the following changes to AdvantEDGE:
1. Patch to demo3 service:
    - Updates AMS with contextTransferState when UE moves from one mep zone to another
2. Patch to AMS:
    - If the contextTransferState is complete, AMS to not send a state transfer notification.
