### PR TITLE
Demo3 Context Transfer Fixes

### DIFF
--- a/go-apps/meep-ams/server/ams.go
+++ b/go-apps/meep-ams/server/ams.go
@@ -67,6 +67,7 @@ const defaultScopeOfLocality = "MEC_SYSTEM"
 const defaultConsumedLocalOnly = true
 const appTerminationPath = "notifications/mec011/appTermination"
 const serviceAppVersion = "2.1.1"
+const USER_CTX_TRANSFER_COMPLETED = "USER_CONTEXT_TRANSFER_COMPLETED"
 
 // App Info fields
 const (
@@ -784,7 +785,7 @@ func sendMpNotifications(currentAppId string, targetAppId string, assocId *Assoc
 			// Find matching Assoc ID
 			found := false
 			for _, filterAssocId := range subOrig.FilterCriteria.AssociateId {
-				if assocId.Type_ == filterAssocId.Type_ && assocId.Value == filterAssocId.Value {
+				if *assocId.Type_ == *filterAssocId.Type_ && assocId.Value == filterAssocId.Value {
 					found = true
 					break
 				}
@@ -1757,6 +1758,9 @@ func refreshTrackedDevCtxOwner(appName string) {
 		} else {
 			// Perform context transfer only if current App is no longer a valid target
 			ctxTransferRequired := true
+			if trackedDev[FieldCtxTransferState] == USER_CTX_TRANSFER_COMPLETED {
+				ctxTransferRequired = false
+			}
 			for _, targetAppId := range targetAppIds {
 				if targetAppId == currentAppId {
 					ctxTransferRequired = false


### PR DESCRIPTION
This PR makes the following changes to AdvantEDGE:

1. Patch to demo3 service:
- Updates AMS with context transfer state when UE moves from one mep zone to another.
- Added an amsSetDevice func which adds or updates the device and sets the context transfer state
2. Patch to AMS:
- If the contextTransferState is complete, AMS to not send a state transfer notification. 